### PR TITLE
Add esp32 support

### DIFF
--- a/.github/workflows/platformio.yaml
+++ b/.github/workflows/platformio.yaml
@@ -6,6 +6,7 @@ on:
       - master
   pull_request:
     types: [assigned, opened, synchronize, reopened]
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/platformio.yaml
+++ b/.github/workflows/platformio.yaml
@@ -35,4 +35,4 @@ jobs:
       run: |
         cp "SRC/ShineWiFi-ModBus/Config.h.example" "SRC/ShineWiFi-ModBus/Config.h"
     - name: Run PlatformIO
-      run: pio run
+      run: pio run -e ShineWifiX -e lolin32 -e nodemcu-32s

--- a/.github/workflows/platformio.yaml
+++ b/.github/workflows/platformio.yaml
@@ -1,12 +1,12 @@
 name: PlatformIO CI
 
 on:
+  workflow_dispatch: null
   push:
     branches:
       - master
   pull_request:
     types: [assigned, opened, synchronize, reopened]
-  workflow_dispatch:
 
 jobs:
   build:

--- a/SRC/ShineWiFi-ModBus/Config.h.example
+++ b/SRC/ShineWiFi-ModBus/Config.h.example
@@ -40,6 +40,8 @@
 #define AP_BUTTON_PRESSED ( analogRead(A0) < 50 )
 // For generic EPS8622 boards you can use a digital pin of your choice
 // #define AP_BUTTON_PRESSED ( digitalRead(1) == HIGH )
+// For boards without any button you can detect double resets with the Double reset detector by setting this to 1
+#define ENABLE_DOUBLE_RESET 0
 
 // Timer definitions:
 //    REFRESH_TIMER: Modbus polling rate [ms]

--- a/SRC/ShineWiFi-ModBus/Config.h.example
+++ b/SRC/ShineWiFi-ModBus/Config.h.example
@@ -18,10 +18,6 @@
 // Setting this define to 1 will enable a web page (<ip>/debug) where debug messages can be displayed
 #define ENABLE_WEB_DEBUG 0
 
-// Identification for MQTT broker
-// If you have connected more than one inverter to the same broker the Id has to be different
-#define MQTT_ID           "GrowattWL"
-
 // Setting this flag to 1 will simulate the inverter
 // This could be helpful if it is night and the inverter is not working or
 // during development where the stick is not connected to the inverter

--- a/SRC/ShineWiFi-ModBus/Growatt.cpp
+++ b/SRC/ShineWiFi-ModBus/Growatt.cpp
@@ -251,7 +251,7 @@ float Growatt::GetEnergyTotal()
 }
 
 // in 0.1 s
-uint32 Growatt::GetOperatingTime()
+uint32_t Growatt::GetOperatingTime()
 {
   return _Data.u32OperatingTime/2;
 }

--- a/SRC/ShineWiFi-ModBus/Growatt.h
+++ b/SRC/ShineWiFi-ModBus/Growatt.h
@@ -151,7 +151,7 @@ class Growatt
     float            GetAcPower();
     float            GetEnergyToday();
     float            GetEnergyTotal();
-    uint32           GetOperatingTime();
+    uint32_t         GetOperatingTime();
     float            GetInverterTemperature();
     uint16_t         GetPwrLimit();
     uint16_t         GetEnExportLimit();

--- a/SRC/ShineWiFi-ModBus/ShineWiFi-ModBus.ino
+++ b/SRC/ShineWiFi-ModBus/ShineWiFi-ModBus.ino
@@ -93,6 +93,8 @@ bool StartedConfigAfterBoot = false;
 #define LED_RT 2  // GPIO2
 #define LED_BL 16 // GPIO16
 
+#define FORMAT_LITTLEFS_IF_FAILED true
+
 byte btnPressed = 0;
 
 #define NUM_OF_RETRIES 5
@@ -313,7 +315,7 @@ void setup()
     #endif
     WEB_DEBUG_PRINT("Setup()")
 
-    LittleFS.begin();
+    LittleFS.begin(FORMAT_LITTLEFS_IF_FAILED);
     #if MQTT_SUPPORTED == 1 
         mqttserver = load_from_file(serverfile, "10.1.2.3");
         mqttport = load_from_file(portfile, "1883");
@@ -555,7 +557,6 @@ void handlePostData()
                 sprintf(msg, "It is not possible to write into Input Registers");
             }
         }
-
         httpServer.send(200, "text/plain", msg);
         return;
     }

--- a/SRC/ShineWiFi-ModBus/ShineWiFi-ModBus.ino
+++ b/SRC/ShineWiFi-ModBus/ShineWiFi-ModBus.ino
@@ -49,6 +49,7 @@ e.g. C:\Users\<username>\AppData\Local\Temp\arduino_build_533155
 // Rename the Config.h.example from the repo to Config.h and add all your config data to it
 // The Config.h has been added to the .gitignore, so that your secrets will be kept
 #include "Config.h"
+#include <ESPHTTPUpdateServer.h>
 
 #if ENABLE_WEB_DEBUG == 1
 char acWebDebug[1024] = "";
@@ -92,7 +93,6 @@ bool StartedConfigAfterBoot = false;
 #define LED_RT 2  // GPIO2
 #define LED_BL 16 // GPIO16
 
-#define BUTTON A0 // GPIOA0 / ADC
 byte btnPressed = 0;
 
 #define NUM_OF_RETRIES 5
@@ -113,7 +113,7 @@ long previousConnectTryMillis = 0;
 #endif
 Growatt      Inverter;
 WebServer httpServer(80);
-//ESP8266HTTPUpdateServer httpUpdater;
+ESPHTTPUpdateServer httpUpdater;
 WiFiManager wm;
 WiFiManagerParameter* custom_mqtt_server = NULL;
 WiFiManagerParameter* custom_mqtt_port = NULL;
@@ -305,6 +305,7 @@ void setup()
     pinMode(LED_GN, OUTPUT);
     pinMode(LED_RT, OUTPUT);
     pinMode(LED_BL, OUTPUT);
+    pinMode(AP_BUTTON_PIN, INPUT);
 
     #if ENABLE_DEBUG_OUTPUT == 1     
         Serial.begin(115200);
@@ -371,7 +372,7 @@ void setup()
     }
 
     #if MQTT_SUPPORTED == 1
-        uint16 port = mqttport.toInt();
+        uint16_t port = mqttport.toInt();
         if (port == 0)
             port = 1883;
         #if ENABLE_DEBUG_OUTPUT == 1
@@ -393,7 +394,7 @@ void setup()
 
     InverterReconnect();
 
-    //httpUpdater.setup(&httpServer, update_path, UPDATE_USER, UPDATE_PASSWORD);
+    httpUpdater.setup(&httpServer, update_path, UPDATE_USER, UPDATE_PASSWORD);
     httpServer.begin();
 }
 
@@ -584,6 +585,7 @@ void loop()
             {
                 #if ENABLE_DEBUG_OUTPUT == 1
                     Serial.println("Handle press");
+
                 #endif
                 StartedConfigAfterBoot = true;
             }
@@ -594,6 +596,7 @@ void loop()
             #if ENABLE_DEBUG_OUTPUT == 1
                 Serial.print("Btn pressed");
             #endif
+                    
         }
         else
         {
@@ -667,7 +670,7 @@ void loop()
                 #endif
                 {
                     WEB_DEBUG_PRINT("UpdateData() successful")
-                        u16PacketCnt++;
+                    u16PacketCnt++;
                     u8RetryCounter = NUM_OF_RETRIES;
                     CreateJson(JsonString);
 

--- a/SRC/ShineWiFi-ModBus/ShineWiFi-ModBus.ino
+++ b/SRC/ShineWiFi-ModBus/ShineWiFi-ModBus.ino
@@ -56,13 +56,14 @@ e.g. C:\Users\<username>\AppData\Local\Temp\arduino_build_533155
 #include <ESPHTTPUpdateServer.h>
 #endif
 
+#ifdef ENABLE_DOUBLE_RESET
 #define ESP_DRD_USE_LITTLEFS    true
 #define ESP_DRD_USE_EEPROM      false
 #define DRD_TIMEOUT             10
 #define DRD_ADDRESS             0
 #include <ESP_DoubleResetDetector.h> 
-
 DoubleResetDetector* drd;
+#endif
 
 #if ENABLE_WEB_DEBUG == 1
 char acWebDebug[1024] = "";
@@ -349,7 +350,9 @@ void setup()
     #endif
     WEB_DEBUG_PRINT("Setup()");
     
+    #ifdef ENABLE_DOUBLE_RESET
     drd = new DoubleResetDetector(DRD_TIMEOUT, DRD_ADDRESS);
+    #endif
 
     pinMode(LED_GN, OUTPUT);
     pinMode(LED_RT, OUTPUT);
@@ -369,12 +372,14 @@ void setup()
         mqttpwd = load_from_file(secretfile, "");
     #endif
 
+    #ifdef ENABLE_DOUBLE_RESET
     if (drd->detectDoubleReset()) { 
         #if ENABLE_DEBUG_OUTPUT == 1     
             Serial.println(F("Double reset detected"));
         #endif 
         StartedConfigAfterBoot = true; 
     }
+    #endif
 
     WiFi.hostname(HOSTNAME);
     WiFi.mode(WIFI_STA); // explicitly set mode, esp defaults to STA+AP
@@ -624,7 +629,9 @@ long WifiRetryTimer = 0;
 
 void loop()
 {
+    #ifdef ENABLE_DOUBLE_RESET
     drd->loop();
+    #endif
 
     long now = millis();
     long lTemp;

--- a/SRC/ShineWiFi-ModBus/ShineWiFi-ModBus.ino
+++ b/SRC/ShineWiFi-ModBus/ShineWiFi-ModBus.ino
@@ -121,11 +121,11 @@ WiFiManagerParameter* custom_mqtt_topic = NULL;
 WiFiManagerParameter* custom_mqtt_user = NULL;
 WiFiManagerParameter* custom_mqtt_pwd = NULL;
 
-const static char* serverfile = "mqtts";
-const static char* portfile = "mqttp";
-const static char* topicfile = "mqttt";
-const static char* userfile = "mqttu";
-const static char* secretfile = "mqttw";
+const static char* serverfile = "/mqtts";
+const static char* portfile = "/mqttp";
+const static char* topicfile = "/mqttt";
+const static char* userfile = "/mqttu";
+const static char* secretfile = "/mqttw";
 
 String mqttserver = "";
 String mqttport = "";
@@ -306,14 +306,20 @@ void setup()
     pinMode(LED_RT, OUTPUT);
     pinMode(LED_BL, OUTPUT);
 
+    #if ENABLE_DEBUG_OUTPUT == 1     
+        Serial.begin(115200);
+        Serial.println(F("Setup()"));
+    #endif
     WEB_DEBUG_PRINT("Setup()")
 
     LittleFS.begin();
-    mqttserver = load_from_file(serverfile, "10.1.2.3");
-    mqttport = load_from_file(portfile, "1883");
-    mqtttopic = load_from_file(topicfile, "energy/solar");
-    mqttuser = load_from_file(userfile, "");
-    mqttpwd = load_from_file(secretfile, "");
+    #if MQTT_SUPPORTED == 1 
+        mqttserver = load_from_file(serverfile, "10.1.2.3");
+        mqttport = load_from_file(portfile, "1883");
+        mqtttopic = load_from_file(topicfile, "energy/solar");
+        mqttuser = load_from_file(userfile, "");
+        mqttpwd = load_from_file(secretfile, "");
+    #endif
 
     WiFi.hostname(HOSTNAME);
     WiFi.mode(WIFI_STA); // explicitly set mode, esp defaults to STA+AP

--- a/SRC/ShineWiFi-ModBus/ShineWiFi-ModBus.ino
+++ b/SRC/ShineWiFi-ModBus/ShineWiFi-ModBus.ino
@@ -63,7 +63,9 @@ uint16_t u16WebMsgNo = 0;
 // ---------------------------------------------------------------
 
 #include "LittleFS.h"
-#include <ESP8266WiFi.h>
+#include <WiFi.h>
+#include <WebServer.h>
+
 
 #if MQTT_SUPPORTED == 1
 #include <PubSubClient.h>
@@ -76,7 +78,6 @@ uint16_t u16WebMsgNo = 0;
 #endif
 
 #include "Growatt.h"
-#include <ESP8266HTTPUpdateServer.h>
 bool StartedConfigAfterBoot = false;
 #define CONFIG_PORTAL_MAX_TIME_SECONDS 300
 #include <WiFiManager.h> // https://github.com/tzapu/WiFiManager
@@ -111,8 +112,8 @@ PubSubClient MqttClient(espClient);
 long previousConnectTryMillis = 0;
 #endif
 Growatt      Inverter;
-ESP8266WebServer httpServer(80);
-ESP8266HTTPUpdateServer httpUpdater;
+WebServer httpServer(80);
+//ESP8266HTTPUpdateServer httpUpdater;
 WiFiManager wm;
 WiFiManagerParameter* custom_mqtt_server = NULL;
 WiFiManagerParameter* custom_mqtt_port = NULL;
@@ -386,7 +387,7 @@ void setup()
 
     InverterReconnect();
 
-    httpUpdater.setup(&httpServer, update_path, UPDATE_USER, UPDATE_PASSWORD);
+    //httpUpdater.setup(&httpServer, update_path, UPDATE_USER, UPDATE_PASSWORD);
     httpServer.begin();
 }
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -34,6 +34,7 @@ platform = espressif32
 board = nodemcu-32s
 framework = arduino
 build_flags = "-D MQTT_MAX_PACKET_SIZE=512"
+board_build.filesystem = littlefs
 lib_deps = 
     ArduinoOTA
     knolleary/PubSubClient@^2.8

--- a/platformio.ini
+++ b/platformio.ini
@@ -7,11 +7,10 @@
 ;
 ; Please visit documentation for the other options and examples
 ; https://docs.platformio.org/page/projectconf.html
-src_dir = SRC/ShineWiFi-ModBus
-default_envs = ShineWifiX
- 
 [platformio]
-default_envs = lolin32
+default_envs = ShineWifiX
+src_dir = SRC/ShineWiFi-ModBus
+
 
 [env]
 monitor_speed = 115200

--- a/platformio.ini
+++ b/platformio.ini
@@ -7,10 +7,11 @@
 ;
 ; Please visit documentation for the other options and examples
 ; https://docs.platformio.org/page/projectconf.html
-[platformio]
 src_dir = SRC/ShineWiFi-ModBus
 default_envs = ShineWifiX
-
+ 
+[platformio]
+default_envs = lolin32
 
 [env]
 monitor_speed = 115200
@@ -28,34 +29,32 @@ lib_deps =
     4-20ma/ModbusMaster@^2.0.1
     bluemurder/ESP8266-ping@^2.0.1
     https://github.com/tzapu/WiFiManager#94bb90322bf85de2c9ec592858f20643161bc11f
+    https://github.com/khoih-prog/ESP_DoubleResetDetector#bce10ef01f3d4864a07ef31fdec2ad65adb3e5b8
 
 [env:nodemcu-32s]
 platform = espressif32
 board = nodemcu-32s
 framework = arduino
-build_flags = "-D MQTT_MAX_PACKET_SIZE=512"
 board_build.filesystem = littlefs
 lib_deps = 
     ArduinoOTA
     knolleary/PubSubClient@^2.8
     4-20ma/ModbusMaster@^2.0.1
-    bluemurder/ESP8266-ping@^2.0.1
-    https://github.com/tzapu/WiFiManager
-    https://github.com/tobiasfaust/ESPHTTPUpdateServer
+    https://github.com/tzapu/WiFiManager#94bb90322bf85de2c9ec592858f20643161bc11f
+    https://github.com/tobiasfaust/ESPHTTPUpdateServer#9546fdadf688d782b80745cdadf986ba1c441c04
+    https://github.com/khoih-prog/ESP_DoubleResetDetector#bce10ef01f3d4864a07ef31fdec2ad65adb3e5b8
+lib_ignore=LittleFS_esp32
     
 [env:lolin32]
 platform = espressif32
 board = lolin32
 framework = arduino
-build_flags = "-D MQTT_MAX_PACKET_SIZE=512"
 board_build.filesystem = littlefs
 lib_deps = 
     ArduinoOTA
     knolleary/PubSubClient@^2.8
     4-20ma/ModbusMaster@^2.0.1
-    https://github.com/tzapu/WiFiManager
-    https://github.com/tobiasfaust/ESPHTTPUpdateServer
-
-
-
-    
+    https://github.com/tzapu/WiFiManager#94bb90322bf85de2c9ec592858f20643161bc11f
+    https://github.com/tobiasfaust/ESPHTTPUpdateServer#9546fdadf688d782b80745cdadf986ba1c441c04
+    https://github.com/khoih-prog/ESP_DoubleResetDetector#bce10ef01f3d4864a07ef31fdec2ad65adb3e5b8
+lib_ignore=LittleFS_esp32

--- a/platformio.ini
+++ b/platformio.ini
@@ -43,7 +43,18 @@ lib_deps =
     https://github.com/tzapu/WiFiManager
     https://github.com/tobiasfaust/ESPHTTPUpdateServer
     
-
+[env:lolin32]
+platform = espressif32
+board = lolin32
+framework = arduino
+build_flags = "-D MQTT_MAX_PACKET_SIZE=512"
+board_build.filesystem = littlefs
+lib_deps = 
+    ArduinoOTA
+    knolleary/PubSubClient@^2.8
+    4-20ma/ModbusMaster@^2.0.1
+    https://github.com/tzapu/WiFiManager
+    https://github.com/tobiasfaust/ESPHTTPUpdateServer
 
 
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -41,3 +41,10 @@ lib_deps =
     4-20ma/ModbusMaster@^2.0.1
     bluemurder/ESP8266-ping@^2.0.1
     https://github.com/tzapu/WiFiManager
+    https://github.com/tobiasfaust/ESPHTTPUpdateServer
+    
+
+
+
+
+    

--- a/platformio.ini
+++ b/platformio.ini
@@ -28,3 +28,15 @@ lib_deps =
     4-20ma/ModbusMaster@^2.0.1
     bluemurder/ESP8266-ping@^2.0.1
     https://github.com/tzapu/WiFiManager#94bb90322bf85de2c9ec592858f20643161bc11f
+
+[env:nodemcu-32s]
+platform = espressif32
+board = nodemcu-32s
+framework = arduino
+build_flags = "-D MQTT_MAX_PACKET_SIZE=512"
+lib_deps = 
+    ArduinoOTA
+    knolleary/PubSubClient@^2.8
+    4-20ma/ModbusMaster@^2.0.1
+    bluemurder/ESP8266-ping@^2.0.1
+    https://github.com/tzapu/WiFiManager


### PR DESCRIPTION
### Summary

* Makes it possible to build this project on esp32 boards (lolin32). 
* Add support for double reset as the lolin only has a reset button
* Make it possible too manually trigger the gh action workflow
* Automatic handling of mqtt ids
* Now rebased to master

### Tested

* Installs on ESP8266 and ESP32
* Wifi&Website do load
* mqtt connection works
* Connection to inverter and reporting works with lolin32
* Connection to inverter is untested with esp8266
