### PR TITLE
Fix client id generation

### DIFF
--- a/SRC/ShineWiFi-ModBus/ShineMqtt.cpp
+++ b/SRC/ShineWiFi-ModBus/ShineMqtt.cpp
@@ -28,8 +28,7 @@ String ShineMqtt::getId() {
 #elif ESP32
   uint64_t id = ESP.getEfuseMac();
 #endif
-
-  return String("Growatt" + id);
+  return "Growatt" + String(id & 0xffffffff);
 }
 
 // -------------------------------------------------------


### PR DESCRIPTION
Client ID sometimes contained special characters which made the mqtt connection fail on some devices.

Fixes #90 