### PR TITLE
Add support for "signed" registers

### DIFF
--- a/SRC/ShineWiFi-ModBus/Growatt.h
+++ b/SRC/ShineWiFi-ModBus/Growatt.h
@@ -2,6 +2,7 @@
 #define _GROWATT_H_
 
 #include "GrowattTypes.h"
+#include <ArduinoJson.h>
 
 class Growatt {
  public:
@@ -32,6 +33,7 @@ class Growatt {
 
   eDevice_t _InitModbusCommunication();
   static double _round2(double value);
+  void JSONAddReg(sGrowattModbusReg_t* reg, JsonDocument* doc);
 };
 
 #endif  // _GROWATT_H_

--- a/SRC/ShineWiFi-ModBus/GrowattTypes.h
+++ b/SRC/ShineWiFi-ModBus/GrowattTypes.h
@@ -44,6 +44,8 @@ typedef enum {
 typedef enum {
   SIZE_16BIT,
   SIZE_32BIT,
+  SIZE_16BIT_S,
+  SIZE_32BIT_S,
 } RegisterSize_t;
 
 typedef struct {

--- a/SRC/ShineWiFi-ModBus/ShineWiFi-ModBus.ino
+++ b/SRC/ShineWiFi-ModBus/ShineWiFi-ModBus.ino
@@ -114,7 +114,7 @@ WiFiManager wm;
     const static char* secretfile = "/mqttw";
 #endif
 
-char JsonString[MQTT_MAX_PACKET_SIZE] = "{\"InverterStatus\": -1 }";
+char JSONChars[MQTT_MAX_PACKET_SIZE] = "{\"InverterStatus\": -1 }";
 
 // -------------------------------------------------------
 // Check the WiFi status and reconnect if necessary
@@ -383,16 +383,16 @@ void setupMenu(bool enableCustomParams){
 
 void SendJsonSite(void)
 {
-    JsonString[0] = '\0';
-    Inverter.CreateJson(JsonString, WiFi.macAddress().c_str());
-    httpServer.send(200, "application/json", JsonString);
+    JSONChars[0] = '\0';
+    Inverter.CreateJson(JSONChars, WiFi.macAddress().c_str());
+    httpServer.send(200, "application/json", JSONChars);
 }
 
 void SendUiJsonSite(void)
 {
-    JsonString[0] = '\0';
-    Inverter.CreateUIJson(JsonString);
-    httpServer.send(200, "application/json", JsonString);
+    JSONChars[0] = '\0';
+    Inverter.CreateUIJson(JSONChars);
+    httpServer.send(200, "application/json", JSONChars);
 }
 
 void StartConfigAccessPoint(void)
@@ -426,7 +426,7 @@ void handlePostData()
     uint16_t u16Tmp;
     uint32_t u32Tmp;
 
-    msg = JsonString;
+    msg = JSONChars;
     msg[0] = 0;
 
     if (!httpServer.hasArg("reg") || !httpServer.hasArg("val"))
@@ -630,11 +630,11 @@ void loop()
                     u8RetryCounter = NUM_OF_RETRIES;
 
                     // Create JSON string
-                    JsonString[0] = '\0';
-                    Inverter.CreateJson(JsonString, WiFi.macAddress().c_str());
+                    JSONChars[0] = '\0';
+                    Inverter.CreateJson(JSONChars, WiFi.macAddress().c_str());
 
                     #if MQTT_SUPPORTED == 1
-                    shineMqtt.mqttPublish(JsonString);
+                    shineMqtt.mqttPublish(JSONChars);
                     #endif
 
                     digitalWrite(LED_RT, 0); // clear red led if everything is ok
@@ -651,9 +651,9 @@ void loop()
                     else
                     {
                         WEB_DEBUG_PRINT("Retry counter\n")
-                        sprintf(JsonString, "{\"InverterStatus\": -1 }");
+                        sprintf(JSONChars, "{\"InverterStatus\": -1 }");
                         #if MQTT_SUPPORTED == 1
-                            shineMqtt.mqttPublish(JsonString);
+                            shineMqtt.mqttPublish(JSONChars);
                         #endif
                         digitalWrite(LED_RT, 1); // set red led in case of error
                     }


### PR DESCRIPTION
As SPF protocol shows, battery balance are shown as "signed" value, e.g. if we have value -1000 it means battery being charged, if it is 1000 it means battery is discharged.
(Holding register 77, 32-bit value, SPF5000 Modbus protocol) Tested only on 32-bit input register.

Signed-off-by: Denys Fedoryshchenko <denys.f@collabora.com>