### PR TITLE
add RemoteDebug

### DIFF
--- a/SRC/ShineWiFi-ModBus/Config.h.example
+++ b/SRC/ShineWiFi-ModBus/Config.h.example
@@ -35,6 +35,8 @@
 
 // Setting this define to 1 will enable a web page (<ip>/debug) where debug messages can be displayed
 #define ENABLE_WEB_DEBUG 1
+// Setting this define to 1 will enable Remote Debug
+// #define ENABLE_REMOTE_DEBUG 1
 
 // Enable TLS connection from stick to broker. Make sure to update port and hostname to match the cert
 // of the mqtt broker as well. Change this CERT to your custom mqtt cert.

--- a/SRC/ShineWiFi-ModBus/Growatt.cpp
+++ b/SRC/ShineWiFi-ModBus/Growatt.cpp
@@ -297,27 +297,34 @@ bool Growatt::ReadInputReg(uint16_t adr, uint32_t* result) {
   return false;
 }
 
-double Growatt::_round2(double value) {
-  return (int)(value * 100 + 0.5) / 100.0;
+double Growatt::roundByResolution(const double& value,
+                                  const float& resolution) {
+  int res = 1 / resolution;
+  return int32_t(value * res + 0.5) / res;
 }
 
 void Growatt::JSONAddReg(sGrowattModbusReg_t* reg, JsonDocument* doc) {
   char* name = reg->name;
   RegisterSize_t size = reg->size;
-  float mult = reg->multiplier;
-  uint32_t value = reg->value;
+  const float& mult = reg->multiplier;
+  const uint32_t& value = reg->value;
+  const float& resolution = reg->resolution;
 
   switch (size) {
     case SIZE_16BIT_S:
-      (*doc)[name] = (mult == (int)mult) ? (int16_t)value * mult
-                                         : _round2((int16_t)value * mult);
+      (*doc)[name] = (mult == (int)mult)
+                         ? (int16_t)value * mult
+                         : roundByResolution((int16_t)value * mult, resolution);
       break;
     case SIZE_32BIT_S:
-      (*doc)[name] = (mult == (int)mult) ? (int32_t)value * mult
-                                         : _round2((int32_t)value * mult);
+      (*doc)[name] = (mult == (int)mult)
+                         ? (int32_t)value * mult
+                         : roundByResolution((int32_t)value * mult, resolution);
       break;
     default:
-      (*doc)[name] = (mult == (int)mult) ? value * mult : _round2(value * mult);
+      (*doc)[name] = (mult == (int)mult)
+                         ? value * mult
+                         : roundByResolution(value * mult, resolution);
   }
 }
 
@@ -370,8 +377,9 @@ void Growatt::CreateUIJson(char* Buffer) {
         arr.add(_Protocol.InputRegisters[i].value *
                 _Protocol.InputRegisters[i].multiplier);
       } else {
-        arr.add(_round2(_Protocol.InputRegisters[i].value *
-                        _Protocol.InputRegisters[i].multiplier));
+        arr.add(roundByResolution(_Protocol.InputRegisters[i].value *
+                                      _Protocol.InputRegisters[i].multiplier,
+                                  _Protocol.InputRegisters[i].resolution));
       }
       if (strcmp(_Protocol.InputRegisters[i].name, "InverterStatus") == 0 &&
           _Protocol.InputRegisters[i].value < statusStrLength) {
@@ -394,8 +402,9 @@ void Growatt::CreateUIJson(char* Buffer) {
         arr.add(_Protocol.HoldingRegisters[i].value *
                 _Protocol.HoldingRegisters[i].multiplier);
       } else {
-        arr.add(_round2(_Protocol.HoldingRegisters[i].value *
-                        _Protocol.HoldingRegisters[i].multiplier));
+        arr.add(roundByResolution(_Protocol.HoldingRegisters[i].value *
+                                      _Protocol.HoldingRegisters[i].multiplier,
+                                  _Protocol.InputRegisters[i].resolution));
       }
       if (strcmp(_Protocol.HoldingRegisters[i].name, "InverterStatus") == 0 &&
           _Protocol.HoldingRegisters[i].value < statusStrLength) {

--- a/SRC/ShineWiFi-ModBus/Growatt.cpp
+++ b/SRC/ShineWiFi-ModBus/Growatt.cpp
@@ -7,6 +7,7 @@
 #ifndef _SHINE_CONFIG_H_
 #error Please rename Config.h.example to Config.h
 #endif
+#include "WebDebug.h"
 
 #if GROWATT_MODBUS_VERSION == 120
 #include "Growatt120.h"
@@ -94,10 +95,16 @@ bool Growatt::ReadInputRegisters() {
 
   // read each fragment separately
   for (int i = 0; i < _Protocol.InputFragmentCount; i++) {
+    #ifdef ENABLE_REMOTE_DEBUG
+    rdebugD("read segment %d from 0x%08x length %d: \n", i,      _Protocol.InputReadFragments[i].StartAddress, _Protocol.InputReadFragments[i].FragmentSize);
+    #endif
     res =
         Modbus.readInputRegisters(_Protocol.InputReadFragments[i].StartAddress,
                                   _Protocol.InputReadFragments[i].FragmentSize);
     if (res == Modbus.ku8MBSuccess) {
+      #ifdef ENABLE_REMOTE_DEBUG
+      rdebugD("ok");
+      #endif
       for (int j = 0; j < _Protocol.InputRegisterCount; j++) {
         // make sure the register we try to read is in the fragment
         if (_Protocol.InputRegisters[j].address >=
@@ -121,9 +128,15 @@ bool Growatt::ReadInputRegisters() {
                 (Modbus.getResponseBuffer(registerAddress) << 16) +
                 Modbus.getResponseBuffer(registerAddress + 1);
           }
+          #ifdef ENABLE_REMOTE_DEBUG
+          rdebugD("%d: 0x%08x - %d\n", j, _Protocol.InputRegisters[j].value, _Protocol.InputRegisters[j].value);
+          #endif
         }
       }
     } else {
+      #ifdef ENABLE_REMOTE_DEBUG
+      rdebugV("failed 0x%02x\n", res);
+      #endif
       return false;
     }
   }

--- a/SRC/ShineWiFi-ModBus/Growatt.cpp
+++ b/SRC/ShineWiFi-ModBus/Growatt.cpp
@@ -95,16 +95,18 @@ bool Growatt::ReadInputRegisters() {
 
   // read each fragment separately
   for (int i = 0; i < _Protocol.InputFragmentCount; i++) {
-    #ifdef ENABLE_REMOTE_DEBUG
-    rdebugD("read segment %d from 0x%08x length %d: \n", i,      _Protocol.InputReadFragments[i].StartAddress, _Protocol.InputReadFragments[i].FragmentSize);
-    #endif
+#ifdef ENABLE_REMOTE_DEBUG
+    rdebugD("read segment %d from 0x%08x length %d: \n", i,
+            _Protocol.InputReadFragments[i].StartAddress,
+            _Protocol.InputReadFragments[i].FragmentSize);
+#endif
     res =
         Modbus.readInputRegisters(_Protocol.InputReadFragments[i].StartAddress,
                                   _Protocol.InputReadFragments[i].FragmentSize);
     if (res == Modbus.ku8MBSuccess) {
-      #ifdef ENABLE_REMOTE_DEBUG
+#ifdef ENABLE_REMOTE_DEBUG
       rdebugD("ok");
-      #endif
+#endif
       for (int j = 0; j < _Protocol.InputRegisterCount; j++) {
         // make sure the register we try to read is in the fragment
         if (_Protocol.InputRegisters[j].address >=
@@ -128,15 +130,16 @@ bool Growatt::ReadInputRegisters() {
                 (Modbus.getResponseBuffer(registerAddress) << 16) +
                 Modbus.getResponseBuffer(registerAddress + 1);
           }
-          #ifdef ENABLE_REMOTE_DEBUG
-          rdebugD("%d: 0x%08x - %d\n", j, _Protocol.InputRegisters[j].value, _Protocol.InputRegisters[j].value);
-          #endif
+#ifdef ENABLE_REMOTE_DEBUG
+          rdebugD("%d: 0x%08x - %d\n", j, _Protocol.InputRegisters[j].value,
+                  _Protocol.InputRegisters[j].value);
+#endif
         }
       }
     } else {
-      #ifdef ENABLE_REMOTE_DEBUG
+#ifdef ENABLE_REMOTE_DEBUG
       rdebugV("failed 0x%02x\n", res);
-      #endif
+#endif
       return false;
     }
   }

--- a/SRC/ShineWiFi-ModBus/Growatt.h
+++ b/SRC/ShineWiFi-ModBus/Growatt.h
@@ -32,7 +32,7 @@ class Growatt {
   uint32_t _PacketCnt;
 
   eDevice_t _InitModbusCommunication();
-  static double _round2(double value);
+  double roundByResolution(const double& value, const float& resolution);
   void JSONAddReg(sGrowattModbusReg_t* reg, JsonDocument* doc);
 };
 

--- a/SRC/ShineWiFi-ModBus/Growatt120.cpp
+++ b/SRC/ShineWiFi-ModBus/Growatt120.cpp
@@ -26,263 +26,267 @@ void init_growatt120(sProtocolDefinition_t &Protocol) {
 
   // 0. Inverter Status Inverter run state
   Protocol.InputRegisters[P120_I_STATUS] =
-      sGrowattModbusReg_t{0,    0,    SIZE_16BIT, "InverterStatus", 1,
+      sGrowattModbusReg_t{0,    0,    SIZE_16BIT, "InverterStatus", 1, 1,
                           NONE, true, false};  // 0:waiting, 1:normal, 3:fault
   // 1. Ppv H Input power (high) 0.1W
   Protocol.InputRegisters[P120_INPUT_POWER] = sGrowattModbusReg_t{
-      1, 0, SIZE_32BIT, "InputPower", 0.1, POWER_W, true, true};
+      1, 0, SIZE_32BIT, "InputPower", 0.1, 0.1, POWER_W, true, true};
   // 2. Ppv L Input power (low) 0.1W
   // 3. Vpv1 PV1 voltage 0.1V
   Protocol.InputRegisters[P120_PV1_VOLTAGE] = sGrowattModbusReg_t{
-      3, 0, SIZE_16BIT, "PV1Voltage", 0.1, VOLTAGE, false, false};
+      3, 0, SIZE_16BIT, "PV1Voltage", 0.1, 0.1, VOLTAGE, false, false};
   // 4. PV1Curr PV1 input current 0.1A
   Protocol.InputRegisters[P120_PV1_INPUT_CURRENT] = sGrowattModbusReg_t{
-      4, 0, SIZE_16BIT, "PV1InputCurrent", 0.1, CURRENT, false, false};
+      4, 0, SIZE_16BIT, "PV1InputCurrent", 0.1, 0.1, CURRENT, false, false};
   // 5. Ppv1 H PV1 input power(high) 0.1W
   Protocol.InputRegisters[P120_PV1_INPUT_POWER] = sGrowattModbusReg_t{
-      5, 0, SIZE_32BIT, "PV1InputPower", 0.1, POWER_W, true, true};
+      5, 0, SIZE_32BIT, "PV1InputPower", 0.1, 0.1, POWER_W, true, true};
   // 6. Ppv1 L PV1 input power(low) 0.1W
   // 7. Vpv2 PV2 voltage 0.1V
   Protocol.InputRegisters[P120_PV2_VOLTAGE] = sGrowattModbusReg_t{
-      7, 0, SIZE_16BIT, "PV2Voltage", 0.1, VOLTAGE, false, false};
+      7, 0, SIZE_16BIT, "PV2Voltage", 0.1, 0.1, VOLTAGE, false, false};
   // 8. PV2Curr PV2 input current 0.1A
   Protocol.InputRegisters[P120_PV2_INPUT_CURRENT] = sGrowattModbusReg_t{
-      8, 0, SIZE_16BIT, "PV2InputCurrent", 0.1, CURRENT, false, false};
+      8, 0, SIZE_16BIT, "PV2InputCurrent", 0.1, 0.1, CURRENT, false, false};
   // 9. Ppv2 H PV2 input power (high) 0.1W
   Protocol.InputRegisters[P120_PV2_INPUT_POWER] = sGrowattModbusReg_t{
-      9, 0, SIZE_32BIT, "PV2InputPower", 0.1, POWER_W, true, true};
+      9, 0, SIZE_32BIT, "PV2InputPower", 0.1, 0.1, POWER_W, true, true};
   // 10. Ppv2 L PV2 input power (low) 0.1W
   // 11. Vpv3 PV3 voltage 0.1V
   Protocol.InputRegisters[P120_PV3_VOLTAGE] = sGrowattModbusReg_t{
-      11, 0, SIZE_16BIT, "PV3Voltage", 0.1, VOLTAGE, false, false};
+      11, 0, SIZE_16BIT, "PV3Voltage", 0.1, 0.1, VOLTAGE, false, false};
   // 12. PV3Curr PV3 input current 0.1A
   Protocol.InputRegisters[P120_PV3_INPUT_CURRENT] = sGrowattModbusReg_t{
-      12, 0, SIZE_16BIT, "PV3InputCurrent", 0.1, CURRENT, false, false};
+      12, 0, SIZE_16BIT, "PV3InputCurrent", 0.1, 0.1, CURRENT, false, false};
   // 13. Ppv3 H PV3 input power (high) 0.1W
   Protocol.InputRegisters[P120_PV3_INPUT_POWER] = sGrowattModbusReg_t{
-      13, 0, SIZE_32BIT, "PV3InputPower", 0.1, POWER_W, true, true};
+      13, 0, SIZE_32BIT, "PV3InputPower", 0.1, 0.1, POWER_W, true, true};
   // 14. Ppv3 L PV3 input power (low) 0.1W
   // 15. Vpv4 PV4 voltage 0.1V
   Protocol.InputRegisters[P120_PV4_VOLTAGE] = sGrowattModbusReg_t{
-      15, 0, SIZE_16BIT, "PV4Voltage", 0.1, VOLTAGE, false, false};
+      15, 0, SIZE_16BIT, "PV4Voltage", 0.1, 0.1, VOLTAGE, false, false};
   // 16. PV4Curr PV4 input current 0.1A
   Protocol.InputRegisters[P120_PV4_INPUT_CURRENT] = sGrowattModbusReg_t{
-      16, 0, SIZE_16BIT, "PV4InputCurrent", 0.1, CURRENT, false, false};
+      16, 0, SIZE_16BIT, "PV4InputCurrent", 0.1, 0.1, CURRENT, false, false};
   // 17. Ppv4 H PV4 input power (high) 0.1W
   Protocol.InputRegisters[P120_PV4_INPUT_POWER] = sGrowattModbusReg_t{
-      17, 0, SIZE_32BIT, "PV4InputPower", 0.1, POWER_W, true, true};
+      17, 0, SIZE_32BIT, "PV4InputPower", 0.1, 0.1, POWER_W, true, true};
   // 18. Ppv4 L PV4 input power (low) 0.1W
   // 19. Vpv5 PV5 voltage 0.1V
   Protocol.InputRegisters[P120_PV5_VOLTAGE] = sGrowattModbusReg_t{
-      19, 0, SIZE_16BIT, "PV5Voltage", 0.1, VOLTAGE, false, false};
+      19, 0, SIZE_16BIT, "PV5Voltage", 0.1, 0.1, VOLTAGE, false, false};
   // 20. PV5Curr PV5 input current 0.1A
   Protocol.InputRegisters[P120_PV5_INPUT_CURRENT] = sGrowattModbusReg_t{
-      20, 0, SIZE_16BIT, "PV5InputCurrent", 0.1, CURRENT, false, false};
+      20, 0, SIZE_16BIT, "PV5InputCurrent", 0.1, 0.1, CURRENT, false, false};
   // 21. Ppv5H PV5 input power(high) 0.1W
   Protocol.InputRegisters[P120_PV5_INPUT_POWER] = sGrowattModbusReg_t{
-      21, 0, SIZE_32BIT, "PV5InputPower", 0.1, POWER_W, true, true};
+      21, 0, SIZE_32BIT, "PV5InputPower", 0.1, 0.1, POWER_W, true, true};
   // 22. Ppv5 L PV5 input power(low) 0.1W
   // 23. Vpv6 PV6 voltage 0.1V
   Protocol.InputRegisters[P120_PV6_VOLTAGE] = sGrowattModbusReg_t{
-      23, 0, SIZE_16BIT, "PV6Voltage", 0.1, VOLTAGE, false, false};
+      23, 0, SIZE_16BIT, "PV6Voltage", 0.1, 0.1, VOLTAGE, false, false};
   // 24. PV6Curr PV6 input current 0.1A
   Protocol.InputRegisters[P120_PV6_INPUT_CURRENT] = sGrowattModbusReg_t{
-      24, 0, SIZE_16BIT, "PV6InputCurrent", 0.1, CURRENT, false, false};
+      24, 0, SIZE_16BIT, "PV6InputCurrent", 0.1, 0.1, CURRENT, false, false};
   // 25. Ppv6 H PV6 input power (high) 0.1W
   Protocol.InputRegisters[P120_PV6_INPUT_POWER] = sGrowattModbusReg_t{
-      25, 0, SIZE_32BIT, "PV6InputPower", 0.1, POWER_W, true, true};
+      25, 0, SIZE_32BIT, "PV6InputPower", 0.1, 0.1, POWER_W, true, true};
   // 26. Ppv6 L PV6 input power (low) 0.1W
   // 27. Vpv7 PV7 voltage 0.1V
   Protocol.InputRegisters[P120_PV7_VOLTAGE] = sGrowattModbusReg_t{
-      27, 0, SIZE_16BIT, "PV7Voltage", 0.1, VOLTAGE, false, false};
+      27, 0, SIZE_16BIT, "PV7Voltage", 0.1, 0.1, VOLTAGE, false, false};
   // 28. PV7Curr PV7 input current 0.1A
   Protocol.InputRegisters[P120_PV7_INPUT_CURRENT] = sGrowattModbusReg_t{
-      28, 0, SIZE_16BIT, "PV7InputCurrent", 0.1, CURRENT, false, false};
+      28, 0, SIZE_16BIT, "PV7InputCurrent", 0.1, 0.1, CURRENT, false, false};
   // 29. Ppv7 H PV7 input power (high) 0.1W
   Protocol.InputRegisters[P120_PV7_INPUT_POWER] = sGrowattModbusReg_t{
-      29, 0, SIZE_32BIT, "PV7InputPower", 0.1, POWER_W, true, true};
+      29, 0, SIZE_32BIT, "PV7InputPower", 0.1, 0.1, POWER_W, true, true};
   // 30. Ppv7 L PV7 input power (low) 0.1W
   // 31. Vpv8 PV8 voltage 0.1V
   Protocol.InputRegisters[P120_PV8_VOLTAGE] = sGrowattModbusReg_t{
-      31, 0, SIZE_16BIT, "PV8Voltage", 0.1, VOLTAGE, false, false};
+      31, 0, SIZE_16BIT, "PV8Voltage", 0.1, 0.1, VOLTAGE, false, false};
   // 32. PV8Curr PV8 input current 0.1A
   Protocol.InputRegisters[P120_PV8_INPUT_CURRENT] = sGrowattModbusReg_t{
-      32, 0, SIZE_16BIT, "PV8InputCurrent", 0.1, CURRENT, false, false};
+      32, 0, SIZE_16BIT, "PV8InputCurrent", 0.1, 0.1, CURRENT, false, false};
   // 33. Ppv8 H PV8 input power (high) 0.1W
   Protocol.InputRegisters[P120_PV8_INPUT_POWER] = sGrowattModbusReg_t{
-      33, 0, SIZE_32BIT, "PV8InputPower", 0.1, POWER_W, true, true};
+      33, 0, SIZE_32BIT, "PV8InputPower", 0.1, 0.1, POWER_W, true, true};
   // 34. Ppv8 L PV8 input power (low) 0.1W
   // 35. Pac H Output power (high) 0.1W
   Protocol.InputRegisters[P120_OUTPUT_POWER] = sGrowattModbusReg_t{
-      35, 0, SIZE_32BIT, "OutputPower", 0.1, POWER_W, true, true};
+      35, 0, SIZE_32BIT, "OutputPower", 0.1, 0.1, POWER_W, true, true};
   // 36. Pac L Output power (low) 0.1W
   // 37. Fac Grid frequency 0.01Hz
   Protocol.InputRegisters[P120_GRID_FREQUENCY] = sGrowattModbusReg_t{
-      37, 0, SIZE_16BIT, "GridFrequency", 0.01, FREQUENCY, false, false};
+      37, 0, SIZE_16BIT, "GridFrequency", 0.01, 0.01, FREQUENCY, false, false};
   // 38. Vac1 Three/single phase grid voltage 0.1V
   Protocol.InputRegisters[P120_GRID_L1_VOLTAGE] = sGrowattModbusReg_t{
-      38, 0, SIZE_16BIT, "GridL1Voltage", 0.1, VOLTAGE, false, false};
+      38, 0, SIZE_16BIT, "GridL1Voltage", 0.1, 0.1, VOLTAGE, false, false};
   // 39. Iac1 Three/single phase grid output current 0.1A
   Protocol.InputRegisters[P120_GRID_L1_OUTPUT_CURRENT] = sGrowattModbusReg_t{
-      39, 0, SIZE_16BIT, "GridL1OutputCurrent", 0.1, CURRENT, false, false};
+      39,      0,     SIZE_16BIT, "GridL1OutputCurrent", 0.1, 0.1,
+      CURRENT, false, false};
   // 40. Pac1 H Three/single phase grid output watt(high) 0.1VA
   Protocol.InputRegisters[P120_GRID_L1_OUTPUT_POWER] = sGrowattModbusReg_t{
-      40, 0, SIZE_32BIT, "GridL1OutputPower", 0.1, VA, false, false};
+      40, 0, SIZE_32BIT, "GridL1OutputPower", 0.1, 0.1, VA, false, false};
   // 41. Pac1 L Three/single phase grid output watt(low) 0.1VA
   // 42. Vac2 Three phase grid voltage 0.1V
   Protocol.InputRegisters[P120_GRID_L2_VOLTAGE] = sGrowattModbusReg_t{
-      42, 0, SIZE_16BIT, "GridL2Voltage", 0.1, VOLTAGE, false, false};
+      42, 0, SIZE_16BIT, "GridL2Voltage", 0.1, 0.1, VOLTAGE, false, false};
   // 43. Iac2 Three phase grid output current 0.1A
   Protocol.InputRegisters[P120_GRID_L2_OUTPUT_CURRENT] = sGrowattModbusReg_t{
-      43, 0, SIZE_16BIT, "GridL2OutputCurrent", 0.1, CURRENT, false, false};
+      43,      0,     SIZE_16BIT, "GridL2OutputCurrent", 0.1, 0.1,
+      CURRENT, false, false};
   // 44. Pac2 H Three phase grid output power (high) 0.1VA
   Protocol.InputRegisters[P120_GRID_L2_OUTPUT_POWER] = sGrowattModbusReg_t{
-      44, 0, SIZE_32BIT, "GridL2OutputPower", 0.1, VA, false, false};
+      44, 0, SIZE_32BIT, "GridL2OutputPower", 0.1, 0.1, VA, false, false};
   // 45. Pac2 L Three phase grid output power (low) 0.1VA
   // 46. Vac3 Three phase grid voltage 0.1V
   Protocol.InputRegisters[P120_GRID_L3_VOLTAGE] = sGrowattModbusReg_t{
-      46, 0, SIZE_16BIT, "GridL3Voltage", 0.1, VOLTAGE, false, false};
+      46, 0, SIZE_16BIT, "GridL3Voltage", 0.1, 0.1, VOLTAGE, false, false};
   // 47. Iac3 Three phase grid output current 0.1A
   Protocol.InputRegisters[P120_GRID_L3_OUTPUT_CURRENT] = sGrowattModbusReg_t{
-      47, 0, SIZE_16BIT, "GridL3OutputCurrent", 0.1, CURRENT, false, false};
+      47,      0,     SIZE_16BIT, "GridL3OutputCurrent", 0.1, 0.1,
+      CURRENT, false, false};
   // 48. Pac3 H Three phase grid output power (high) 0.1VA
   Protocol.InputRegisters[P120_GRID_L3_OUTPUT_POWER] = sGrowattModbusReg_t{
-      48, 0, SIZE_32BIT, "GridL3OutputPower", 0.1, VA, false, false};
+      48, 0, SIZE_32BIT, "GridL3OutputPower", 0.1, 0.1, VA, false, false};
   // FRAGMENT 1: END
 
   // FRAGMENT 2: BEGIN
   // 49. Pac3 L Three phase grid output power (low) 0.1VA
   // 50. Vac_RS Three phase grid voltage 0.1V Line voltage
   Protocol.InputRegisters[P120_GRID_RS_VOLTAGE] = sGrowattModbusReg_t{
-      50, 0, SIZE_16BIT, "GridRSVoltage", 0.1, VOLTAGE, false, false};
+      50, 0, SIZE_16BIT, "GridRSVoltage", 0.1, 0.1, VOLTAGE, false, false};
   // 51. Vac_ST Three phase grid voltage 0.1V Line voltage
   Protocol.InputRegisters[P120_GRID_ST_VOLTAGE] = sGrowattModbusReg_t{
-      51, 0, SIZE_16BIT, "GridSTVoltage", 0.1, VOLTAGE, false, false};
+      51, 0, SIZE_16BIT, "GridSTVoltage", 0.1, 0.1, VOLTAGE, false, false};
   // 52. Vac_TR Three phase grid voltage 0.1V Line voltage
   Protocol.InputRegisters[P120_GRID_TR_VOLTAGE] = sGrowattModbusReg_t{
-      52, 0, SIZE_16BIT, "GridTRVoltage", 0.1, VOLTAGE, false, false};
+      52, 0, SIZE_16BIT, "GridTRVoltage", 0.1, 0.1, VOLTAGE, false, false};
   // 53. Eac today H Today generate energy (high) 0.1kWH
   Protocol.InputRegisters[P120_ENERGY_TODAY] = sGrowattModbusReg_t{
-      53, 0, SIZE_32BIT, "EnergyToday", 0.1, POWER_KWH, true, false};
+      53, 0, SIZE_32BIT, "EnergyToday", 0.1, 0.1, POWER_KWH, true, false};
   // 54. Eac today L Today generate energy (low) 0.1kWH
   // 55. Eac total H Total generate energy (high) 0.1kWH
   Protocol.InputRegisters[P120_ENERGY_TOTAL] = sGrowattModbusReg_t{
-      55, 0, SIZE_32BIT, "EnergyTotal", 0.1, POWER_KWH, true, false};
+      55, 0, SIZE_32BIT, "EnergyTotal", 0.1, 0.1, POWER_KWH, true, false};
   // 56. Eac total L Total generate energy (low) 0.1kWH
   // 57. Time total H Work time total (high) 0.5s
   Protocol.InputRegisters[P120_WORK_TIME_TOTAL] = sGrowattModbusReg_t{
-      57, 0, SIZE_32BIT, "WorkTimeTotal", 0.5, SECONDS, false, false};
+      57, 0, SIZE_32BIT, "WorkTimeTotal", 0.5, 1, SECONDS, false, false};
   // 58. Time total L Work time total (low) 0.5s
   // 59. Epv1_today H PV1 Energy today (high) 0.1kWh
   Protocol.InputRegisters[P120_PV1_ENERGY_TODAY] = sGrowattModbusReg_t{
-      59, 0, SIZE_32BIT, "PV1EnergyToday", 0.1, POWER_KWH, false, false};
+      59, 0, SIZE_32BIT, "PV1EnergyToday", 0.1, 0.1, POWER_KWH, false, false};
   // 60. Epv1_today L PV1 Energy today (low) 0.1kWh
   // 61. Epv1_total H PV1 Energy total (high) 0.1kWh
   Protocol.InputRegisters[P120_PV1_ENERGY_TOTAL] = sGrowattModbusReg_t{
-      61, 0, SIZE_32BIT, "PV1EnergyTotal", 0.1, POWER_KWH, false, false};
+      61, 0, SIZE_32BIT, "PV1EnergyTotal", 0.1, 0.1, POWER_KWH, false, false};
   // 62. Epv1_total L PV1 Energy total (low) 0.1kWh
   // 63. Epv2_today H PV2 Energy today (high) 0.1kWh
   Protocol.InputRegisters[P120_PV2_ENERGY_TODAY] = sGrowattModbusReg_t{
-      63, 0, SIZE_32BIT, "PV2EnergyToday", 0.1, POWER_KWH, false, false};
+      63, 0, SIZE_32BIT, "PV2EnergyToday", 0.1, 0.1, POWER_KWH, false, false};
   // 64. Epv2_today L PV2 Energy today (low) 0.1kWh
   // 65. Epv2_total H PV2 Energy total (high) 0.1kWh
   Protocol.InputRegisters[P120_PV2_ENERGY_TOTAL] = sGrowattModbusReg_t{
-      65, 0, SIZE_32BIT, "PV2EnergyTotal", 0.1, POWER_KWH, false, false};
+      65, 0, SIZE_32BIT, "PV2EnergyTotal", 0.1, 0.1, POWER_KWH, false, false};
   // 66. Epv2_total L PV2 Energy total (low) 0.1kWh
   // 67. Epv3_today H PV3 Energy today (high) 0.1kWh
   Protocol.InputRegisters[P120_PV3_ENERGY_TODAY] = sGrowattModbusReg_t{
-      67, 0, SIZE_32BIT, "PV3EnergyToday", 0.1, POWER_KWH, false, false};
+      67, 0, SIZE_32BIT, "PV3EnergyToday", 0.1, 0.1, POWER_KWH, false, false};
   // 68. Epv3_today L PV3 Energy today (low) 0.1kWh
   // 69. Epv3_total H PV3 Energy total (high) 0.1kWh
   Protocol.InputRegisters[P120_PV3_ENERGY_TOTAL] = sGrowattModbusReg_t{
-      69, 0, SIZE_32BIT, "PV3EnergyTotal", 0.1, POWER_KWH, false, false};
+      69, 0, SIZE_32BIT, "PV3EnergyTotal", 0.1, 0.1, POWER_KWH, false, false};
   // 70. Epv3_total L PV3 Energy total (low) 0.1kWh
   // 71. Epv4_today H PV4 Energy today (high) 0.1kWh
   Protocol.InputRegisters[P120_PV4_ENERGY_TODAY] = sGrowattModbusReg_t{
-      71, 0, SIZE_32BIT, "PV4EnergyToday", 0.1, POWER_KWH, false, false};
+      71, 0, SIZE_32BIT, "PV4EnergyToday", 0.1, 0.1, POWER_KWH, false, false};
   // 72. Epv4_today L PV4 Energy today (low) 0.1kWh
   // 73. Epv4_total H PV4 Energy total (high) 0.1kWh
   Protocol.InputRegisters[P120_PV4_ENERGY_TOTAL] = sGrowattModbusReg_t{
-      73, 0, SIZE_32BIT, "PV4EnergyTotal", 0.1, POWER_KWH, false, false};
+      73, 0, SIZE_32BIT, "PV4EnergyTotal", 0.1, 0.1, POWER_KWH, false, false};
   // 74. Epv4_total L PV4 Energy total (low) 0.1kWh
   // 75. Epv5_today H PV5 Energy today (high) 0.1kWh
   Protocol.InputRegisters[P120_PV5_ENERGY_TODAY] = sGrowattModbusReg_t{
-      75, 0, SIZE_32BIT, "PV5EnergyToday", 0.1, POWER_KWH, false, false};
+      75, 0, SIZE_32BIT, "PV5EnergyToday", 0.1, 0.1, POWER_KWH, false, false};
   // 76. Epv5_today L PV5 Energy today (low) 0.1kWh
   // 77. Epv5_total H PV5 Energy total (high) 0.1kWh
   Protocol.InputRegisters[P120_PV5_ENERGY_TOTAL] = sGrowattModbusReg_t{
-      77, 0, SIZE_32BIT, "PV5EnergyTotal", 0.1, POWER_KWH, false, false};
+      77, 0, SIZE_32BIT, "PV5EnergyTotal", 0.1, 0.1, POWER_KWH, false, false};
   // 78. Epv5_total L PV5 Energy total (low) 0.1kWh
   // 79. Epv6_today H PV6 Energy today (high) 0.1kWh
   Protocol.InputRegisters[P120_PV6_ENERGY_TODAY] = sGrowattModbusReg_t{
-      79, 0, SIZE_32BIT, "PV6EnergyToday", 0.1, POWER_KWH, false, false};
+      79, 0, SIZE_32BIT, "PV6EnergyToday", 0.1, 0.1, POWER_KWH, false, false};
   // 80. Epv6_today L PV6Energy today (low) 0.1kWh
   // 81. Epv6_total H PV6 Energy total (high) 0.1kWh
   Protocol.InputRegisters[P120_PV6_ENERGY_TOTAL] = sGrowattModbusReg_t{
-      81, 0, SIZE_32BIT, "PV6EnergyTotal", 0.1, POWER_KWH, false, false};
+      81, 0, SIZE_32BIT, "PV6EnergyTotal", 0.1, 0.1, POWER_KWH, false, false};
   // 82. Epv6_total L PV6 Energy total (low) 0.1kWh
   // 83. Epv7_today H PV7 Energy today (high) 0.1kWh
   Protocol.InputRegisters[P120_PV7_ENERGY_TODAY] = sGrowattModbusReg_t{
-      83, 0, SIZE_32BIT, "PV7EnergyToday", 0.1, POWER_KWH, false, false};
+      83, 0, SIZE_32BIT, "PV7EnergyToday", 0.1, 0.1, POWER_KWH, false, false};
   // 84. Epv7_today L PV7 Energy today (low) 0.1kWh
   // 85. Epv7_total H PV7 Energy total (high) 0.1kWh
   Protocol.InputRegisters[P120_PV7_ENERGY_TOTAL] = sGrowattModbusReg_t{
-      85, 0, SIZE_32BIT, "PV7EnergyTotal", 0.1, POWER_KWH, false, false};
+      85, 0, SIZE_32BIT, "PV7EnergyTotal", 0.1, 0.1, POWER_KWH, false, false};
   // 86. Epv7_total L PV7 Energy total (low) 0.1kWh
   // 87. Epv8_today H PV8 Energy today (high) 0.1kWh
   Protocol.InputRegisters[P120_PV8_ENERGY_TODAY] = sGrowattModbusReg_t{
-      87, 0, SIZE_32BIT, "PV8EnergyToday", 0.1, POWER_KWH, false, false};
+      87, 0, SIZE_32BIT, "PV8EnergyToday", 0.1, 0.1, POWER_KWH, false, false};
   // 88. Epv8_today L PV8Energy today (low) 0.1kWh
   // 89. Epv8_total H PV8 Energy total (high) 0.1kWh
   Protocol.InputRegisters[P120_PV8_ENERGY_TOTAL] = sGrowattModbusReg_t{
-      89, 0, SIZE_32BIT, "PV8EnergyTotal", 0.1, POWER_KWH, false, false};
+      89, 0, SIZE_32BIT, "PV8EnergyTotal", 0.1, 0.1, POWER_KWH, false, false};
   // 90. Epv8_total L PV8 Energy total (low) 0.1kWh
   // 91. Epv_total H PV Energy total (high) 0.1kWh
   Protocol.InputRegisters[P120_PV_ENERGY_TOTAL] = sGrowattModbusReg_t{
-      91, 0, SIZE_32BIT, "PVEnergyTotal", 0.1, POWER_KWH, true, false};
+      91, 0, SIZE_32BIT, "PVEnergyTotal", 0.1, 0.1, POWER_KWH, true, false};
   // 92. Epv_total L PV Energy total (low) 0.1kWh
   // 93. Temp1 Inverter temperature 0.1C
   Protocol.InputRegisters[P120_INVERTER_TEMPERATURE] = sGrowattModbusReg_t{
-      93, 0, SIZE_16BIT, "InverterTemperature", 0.1, TEMPERATURE, true, true};
+      93,          0,    SIZE_16BIT, "InverterTemperature", 0.1, 0.1,
+      TEMPERATURE, true, true};
   // 94. Temp2 The inside IPM in inverter Temperature 0.1C
   Protocol.InputRegisters[P120_INVERTER_IPM_TEMPERATURE] = sGrowattModbusReg_t{
-      94,  0,           SIZE_16BIT, "InverterIPMTemperature",
-      0.1, TEMPERATURE, false,      false};
+      94,          0,     SIZE_16BIT, "InverterIPMTemperature", 0.1, 0.1,
+      TEMPERATURE, false, false};
   // 95. Temp3 Boost temperature 0.1C
   Protocol.InputRegisters[P120_INVERTER_BOOST_TEMPERATURE] =
-      sGrowattModbusReg_t{
-          95,  0,           SIZE_16BIT, "InverterBoostTemperature",
-          0.1, TEMPERATURE, false,      false};
+      sGrowattModbusReg_t{95,   0,   SIZE_16BIT,  "InverterBoostTemperature",
+                          0.1,  0.1, TEMPERATURE, false,
+                          false};
   // 96. Temp4 reserved
   // 97. Temp5 reserved
   // 98. P Bus Voltage P Bus inside Voltage 0.1V
   Protocol.InputRegisters[P120_BUS_P_VOLTAGE] = sGrowattModbusReg_t{
-      98, 0, SIZE_16BIT, "BusPVoltage", 0.1, VOLTAGE, false, false};
+      98, 0, SIZE_16BIT, "BusPVoltage", 0.1, 0.1, VOLTAGE, false, false};
   // 99. N Bus Voltage N Bus inside Voltage 0.1V
   Protocol.InputRegisters[P120_BUS_N_VOLTAGE] = sGrowattModbusReg_t{
-      99, 0, SIZE_16BIT, "BusNVoltage", 0.1, VOLTAGE, false, false};
+      99, 0, SIZE_16BIT, "BusNVoltage", 0.1, 0.1, VOLTAGE, false, false};
   // FRAGMENT 2: END
 
   // FRAGMENT 3: BEGIN
   // 100. IPF Inverter output PF now 0-20000
   // 101. RealOPPercent Real Output power Percent 1%
-  Protocol.InputRegisters[P120_REAL_OUTPUT_POWER] =
-      sGrowattModbusReg_t{101, 0,          SIZE_16BIT, "RealOutputPowerPercent",
-                          1,   PRECENTAGE, false,      false};
+  Protocol.InputRegisters[P120_REAL_OUTPUT_POWER] = sGrowattModbusReg_t{
+      101,        0,     SIZE_16BIT, "RealOutputPowerPercent", 1, 1,
+      PRECENTAGE, false, false};
   // 102. OPFullwatt H Output Maxpower Limited high
   Protocol.InputRegisters[P120_OUTPUT_MAXPOWER_LIMITED] = sGrowattModbusReg_t{
-      102, 0, SIZE_16BIT, "LimitedOutputPower", 1, POWER_W, false, false};
+      102, 0, SIZE_16BIT, "LimitedOutputPower", 1, 1, POWER_W, false, false};
   // 103. OPFullwatt L Output Maxpower Limited low 0.1W
   // 104. DeratingMode DeratingMode // 0:no derate; 1:PV; 2:*; 3:Vac; 4:Fac;
   // 5:Tboost; 6:Tinv; 7:Control; 8:*; 9:*OverBack ByTime; “*”is Reserved
   Protocol.InputRegisters[P120_DERATINGMODE] = sGrowattModbusReg_t{
-      104, 0, SIZE_16BIT, "DeratingMode", 1, NONE, false, false};
+      104, 0, SIZE_16BIT, "DeratingMode", 1, 1, NONE, false, false};
   // 105. Fault code Inverter fault code &*1
   Protocol.InputRegisters[P120_FAULT_CODE] = sGrowattModbusReg_t{
-      105,  0,    SIZE_16BIT, "FaultCode", 1,
-      NONE, true, false};  // 0:no derate; 1:PV; 2:*; 3:Vac; 4:Fac; 5:Tboost;
-                           // 6:Tinv; 7:Control; 8:*; 9:*OverBack ByTime; “*”is
-                           // Reserved
+      105, 0,    SIZE_16BIT, "FaultCode", 1,
+      1,   NONE, true,       false};  // 0:no derate; 1:PV; 2:*; 3:Vac; 4:Fac;
+                                      // 5:Tboost; 6:Tinv; 7:Control; 8:*;
+                                      // 9:*OverBack ByTime; “*”is Reserved
   // 106. Fault Bitcode H Inverter fault code high &*8
   // 107. Fault Bitcode L Inverter fault code low
   // 108. Fault Bit_II H Inverter fault code_II high --预留 mix，
@@ -306,10 +310,10 @@ void init_growatt120(sProtocolDefinition_t &Protocol) {
 
   // FRAGMENT 1: BEGIN
   Protocol.HoldingRegisters[P120_OnOff] =
-      sGrowattModbusReg_t{0, 0, SIZE_16BIT, "OnOff", 1, NONE, true, false};
+      sGrowattModbusReg_t{0, 0, SIZE_16BIT, "OnOff", 1, 1, NONE, true, false};
   Protocol.HoldingRegisters[P120_CMD_MEMORY_STATE] = sGrowattModbusReg_t{
-      2, 0, SIZE_16BIT, "CmdMemoryState", 1, NONE, true, false};
+      2, 0, SIZE_16BIT, "CmdMemoryState", 1, 1, NONE, true, false};
   Protocol.HoldingRegisters[P120_Active_P_Rate] = sGrowattModbusReg_t{
-      3, 0, SIZE_16BIT, "ActivePowerRate", 1, PRECENTAGE, true, false};
+      3, 0, SIZE_16BIT, "ActivePowerRate", 1, 1, PRECENTAGE, true, false};
   // FRAGMENT 1: END
 }

--- a/SRC/ShineWiFi-ModBus/Growatt124.cpp
+++ b/SRC/ShineWiFi-ModBus/Growatt124.cpp
@@ -10,156 +10,166 @@ void init_growatt124(sProtocolDefinition_t &Protocol) {
   // address, value, size, name, multiplier, unit, frontend, plot
   // FEAGMENT 1: BEGIN
   Protocol.InputRegisters[P124_I_STATUS] = sGrowattModbusReg_t{
-      0, 0, SIZE_16BIT, "InverterStatus", 1, NONE, true, false};  // #1
+      0, 0, SIZE_16BIT, "InverterStatus", 1, 1, NONE, true, false};  // #1
   Protocol.InputRegisters[P124_INPUT_POWER] = sGrowattModbusReg_t{
-      1, 0, SIZE_32BIT, "InputPower", 0.1, POWER_W, true, true};  // #2
+      1, 0, SIZE_32BIT, "InputPower", 0.1, 0.1, POWER_W, true, true};  // #2
 
   Protocol.InputRegisters[P124_PV1_VOLTAGE] = sGrowattModbusReg_t{
-      3, 0, SIZE_16BIT, "PV1Voltage", 0.1, VOLTAGE, false, false};  // #3
+      3, 0, SIZE_16BIT, "PV1Voltage", 0.1, 0.1, VOLTAGE, false, false};  // #3
   Protocol.InputRegisters[P124_PV1_CURRENT] = sGrowattModbusReg_t{
-      4, 0, SIZE_16BIT, "PV1InputCurrent", 0.1, CURRENT, false, false};  // #4
-  Protocol.InputRegisters[P124_PV1_POWER] = sGrowattModbusReg_t{
-      5, 0, SIZE_32BIT, "PV1InputPower", 0.1, POWER_W, false, false};  // #5
+      4,       0,     SIZE_16BIT, "PV1InputCurrent", 0.1, 0.1,
+      CURRENT, false, false};  // #4
+  Protocol.InputRegisters[P124_PV1_POWER] =
+      sGrowattModbusReg_t{5,       0,     SIZE_32BIT, "PV1InputPower", 0.1, 0.1,
+                          POWER_W, false, false};  // #5
   Protocol.InputRegisters[P124_PV2_VOLTAGE] = sGrowattModbusReg_t{
-      7, 0, SIZE_16BIT, "PV2Voltage", 0.1, VOLTAGE, false, false};  // #6
+      7, 0, SIZE_16BIT, "PV2Voltage", 0.1, 0.1, VOLTAGE, false, false};  // #6
   Protocol.InputRegisters[P124_PV2_CURRENT] = sGrowattModbusReg_t{
-      8, 0, SIZE_16BIT, "PV2InputCurrent", 0.1, CURRENT, false, false};  // #7
-  Protocol.InputRegisters[P124_PV2_POWER] = sGrowattModbusReg_t{
-      9, 0, SIZE_32BIT, "PV2InputPower", 0.1, POWER_W, false, false};  // #8
+      8,       0,     SIZE_16BIT, "PV2InputCurrent", 0.1, 0.1,
+      CURRENT, false, false};  // #7
+  Protocol.InputRegisters[P124_PV2_POWER] =
+      sGrowattModbusReg_t{9,       0,     SIZE_32BIT, "PV2InputPower", 0.1, 0.1,
+                          POWER_W, false, false};  // #8
 
   Protocol.InputRegisters[P124_PAC] = sGrowattModbusReg_t{
-      35, 0, SIZE_32BIT, "OutputPower", 0.1, POWER_W, true, true};  // #9
-  Protocol.InputRegisters[P124_FAC] =
-      sGrowattModbusReg_t{37,   0,         SIZE_16BIT, "GridFrequency",
-                          0.01, FREQUENCY, false,      false};  // #10
+      35, 0, SIZE_32BIT, "OutputPower", 0.1, 0.1, POWER_W, true, true};  // #9
+  Protocol.InputRegisters[P124_FAC] = sGrowattModbusReg_t{
+      37,        0,     SIZE_16BIT, "GridFrequency", 0.01, 0.01,
+      FREQUENCY, false, false};  // #10
 
-  Protocol.InputRegisters[P124_VAC1] =
-      sGrowattModbusReg_t{38,  0,       SIZE_16BIT, "L1ThreePhaseGridVoltage",
-                          0.1, VOLTAGE, false,      false};  // #11
+  Protocol.InputRegisters[P124_VAC1] = sGrowattModbusReg_t{
+      38,      0,     SIZE_16BIT, "L1ThreePhaseGridVoltage", 0.1, 0.1,
+      VOLTAGE, false, false};  // #11
   Protocol.InputRegisters[P124_IAC1] = sGrowattModbusReg_t{
-      39,  0,       SIZE_16BIT, "L1ThreePhaseGridOutputCurrent",
-      0.1, CURRENT, false,      false};  // #12
-  Protocol.InputRegisters[P124_PAC1] =
-      sGrowattModbusReg_t{40,  0,  SIZE_32BIT, "L1ThreePhaseGridOutputPower",
-                          0.1, VA, false,      false};  // #13
-  Protocol.InputRegisters[P124_VAC2] =
-      sGrowattModbusReg_t{42,  0,       SIZE_16BIT, "L2ThreePhaseGridVoltage",
-                          0.1, VOLTAGE, false,      false};  // #14
+      39,      0,     SIZE_16BIT, "L1ThreePhaseGridOutputCurrent", 0.1, 0.1,
+      CURRENT, false, false};  // #12
+  Protocol.InputRegisters[P124_PAC1] = sGrowattModbusReg_t{
+      40, 0,     SIZE_32BIT, "L1ThreePhaseGridOutputPower", 0.1, 0.1,
+      VA, false, false};  // #13
+  Protocol.InputRegisters[P124_VAC2] = sGrowattModbusReg_t{
+      42,      0,     SIZE_16BIT, "L2ThreePhaseGridVoltage", 0.1, 0.1,
+      VOLTAGE, false, false};  // #14
   Protocol.InputRegisters[P124_IAC2] = sGrowattModbusReg_t{
-      43,  0,       SIZE_16BIT, "L2ThreePhaseGridOutputCurrent",
-      0.1, CURRENT, false,      false};  // #15
-  Protocol.InputRegisters[P124_PAC2] =
-      sGrowattModbusReg_t{44,  0,  SIZE_32BIT, "L2ThreePhaseGridOutputPower",
-                          0.1, VA, false,      false};  // #16
-  Protocol.InputRegisters[P124_VAC3] =
-      sGrowattModbusReg_t{46,  0,       SIZE_16BIT, "L3ThreePhaseGridVoltage",
-                          0.1, VOLTAGE, false,      false};  // #17
+      43,      0,     SIZE_16BIT, "L2ThreePhaseGridOutputCurrent", 0.1, 0.1,
+      CURRENT, false, false};  // #15
+  Protocol.InputRegisters[P124_PAC2] = sGrowattModbusReg_t{
+      44, 0,     SIZE_32BIT, "L2ThreePhaseGridOutputPower", 0.1, 0.1,
+      VA, false, false};  // #16
+  Protocol.InputRegisters[P124_VAC3] = sGrowattModbusReg_t{
+      46,      0,     SIZE_16BIT, "L3ThreePhaseGridVoltage", 0.1, 0.1,
+      VOLTAGE, false, false};  // #17
   Protocol.InputRegisters[P124_IAC3] = sGrowattModbusReg_t{
-      47,  0,       SIZE_16BIT, "L3ThreePhaseGridOutputCurrent",
-      0.1, CURRENT, false,      false};  // #18
-  Protocol.InputRegisters[P124_PAC3] =
-      sGrowattModbusReg_t{48,  0,  SIZE_32BIT, "L3ThreePhaseGridOutputPower",
-                          0.1, VA, false,      false};  // #19
+      47,      0,     SIZE_16BIT, "L3ThreePhaseGridOutputCurrent", 0.1, 0.1,
+      CURRENT, false, false};  // #18
+  Protocol.InputRegisters[P124_PAC3] = sGrowattModbusReg_t{
+      48, 0,     SIZE_32BIT, "L3ThreePhaseGridOutputPower", 0.1, 0.1,
+      VA, false, false};  // #19
   // FEAGMENT 1: END
 
   // FEAGMENT 2: BEGIN
-  Protocol.InputRegisters[P124_EAC_TODAY] =
-      sGrowattModbusReg_t{53,  0,         SIZE_32BIT, "TodayGenerateEnergy",
-                          0.1, POWER_KWH, true,       false};  // #20
-  Protocol.InputRegisters[P124_EAC_TOTAL] =
-      sGrowattModbusReg_t{55,  0,         SIZE_32BIT, "TotalGenerateEnergy",
-                          0.1, POWER_KWH, true,       false};  // #21
-  Protocol.InputRegisters[P124_TIME_TOTAL] = sGrowattModbusReg_t{
-      57, 0, SIZE_32BIT, "TWorkTimeTotal", 0.5, SECONDS, false, false};  // #22
+  Protocol.InputRegisters[P124_EAC_TODAY] = sGrowattModbusReg_t{
+      53,        0,    SIZE_32BIT, "TodayGenerateEnergy", 0.1, 0.1,
+      POWER_KWH, true, false};  // #20
+  Protocol.InputRegisters[P124_EAC_TOTAL] = sGrowattModbusReg_t{
+      55,        0,    SIZE_32BIT, "TotalGenerateEnergy", 0.1, 0.1,
+      POWER_KWH, true, false};  // #21
+  Protocol.InputRegisters[P124_TIME_TOTAL] =
+      sGrowattModbusReg_t{57,      0,     SIZE_32BIT, "TWorkTimeTotal", 0.5, 1,
+                          SECONDS, false, false};  // #22
 
-  Protocol.InputRegisters[P124_EPV1_TODAY] =
-      sGrowattModbusReg_t{59,  0,         SIZE_32BIT, "PV1EnergyToday",
-                          0.1, POWER_KWH, false,      false};  // #23
-  Protocol.InputRegisters[P124_EPV1_TOTAL] =
-      sGrowattModbusReg_t{61,  0,         SIZE_32BIT, "PV1EnergyTotal",
-                          0.1, POWER_KWH, false,      false};  // #24
-  Protocol.InputRegisters[P124_EPV2_TODAY] =
-      sGrowattModbusReg_t{63,  0,         SIZE_32BIT, "PV2EnergyToday",
-                          0.1, POWER_KWH, false,      false};  // #25
-  Protocol.InputRegisters[P124_EPV2_TOTAL] =
-      sGrowattModbusReg_t{65,  0,         SIZE_32BIT, "PV2EnergyTotal",
-                          0.1, POWER_KWH, false,      false};  // #26
+  Protocol.InputRegisters[P124_EPV1_TODAY] = sGrowattModbusReg_t{
+      59,        0,     SIZE_32BIT, "PV1EnergyToday", 0.1, 0.1,
+      POWER_KWH, false, false};  // #23
+  Protocol.InputRegisters[P124_EPV1_TOTAL] = sGrowattModbusReg_t{
+      61,        0,     SIZE_32BIT, "PV1EnergyTotal", 0.1, 0.1,
+      POWER_KWH, false, false};  // #24
+  Protocol.InputRegisters[P124_EPV2_TODAY] = sGrowattModbusReg_t{
+      63,        0,     SIZE_32BIT, "PV2EnergyToday", 0.1, 0.1,
+      POWER_KWH, false, false};  // #25
+  Protocol.InputRegisters[P124_EPV2_TOTAL] = sGrowattModbusReg_t{
+      65,        0,     SIZE_32BIT, "PV2EnergyTotal", 0.1, 0.1,
+      POWER_KWH, false, false};  // #26
   Protocol.InputRegisters[P124_EPV_TOTAL] = sGrowattModbusReg_t{
-      91, 0, SIZE_32BIT, "PVEnergyTotal", 0.1, POWER_KWH, false, false};  // #27
+      91,        0,     SIZE_32BIT, "PVEnergyTotal", 0.1, 0.1,
+      POWER_KWH, false, false};  // #27
 
-  Protocol.InputRegisters[P124_TEMP1] =
-      sGrowattModbusReg_t{93,  0,           SIZE_16BIT, "InverterTemperature",
-                          0.1, TEMPERATURE, true,       true};  // #28
-  Protocol.InputRegisters[P124_TEMP2] =
-      sGrowattModbusReg_t{94,  0,           SIZE_16BIT, "TemperatureInsideIPM",
-                          0.1, TEMPERATURE, false,      false};  // #29
-  Protocol.InputRegisters[P124_TEMP3] =
-      sGrowattModbusReg_t{95,  0,           SIZE_16BIT, "BoostTemperature",
-                          0.1, TEMPERATURE, false,      false};  // #30
+  Protocol.InputRegisters[P124_TEMP1] = sGrowattModbusReg_t{
+      93,          0,    SIZE_16BIT, "InverterTemperature", 0.1, 0.1,
+      TEMPERATURE, true, true};  // #28
+  Protocol.InputRegisters[P124_TEMP2] = sGrowattModbusReg_t{
+      94,          0,     SIZE_16BIT, "TemperatureInsideIPM", 0.1, 0.1,
+      TEMPERATURE, false, false};  // #29
+  Protocol.InputRegisters[P124_TEMP3] = sGrowattModbusReg_t{
+      95,          0,     SIZE_16BIT, "BoostTemperature", 0.1, 0.1,
+      TEMPERATURE, false, false};  // #30
   // FEAGMENT 2: END
 
   // FEAGMENT 3: BEGIN
-  Protocol.InputRegisters[P124_PDISCHARGE] = sGrowattModbusReg_t{
-      1009, 0, SIZE_32BIT, "DischargePower", 0.1, POWER_W, true, true};  // #31
-  Protocol.InputRegisters[P124_PCHARGE] = sGrowattModbusReg_t{
-      1011, 0, SIZE_32BIT, "ChargePower", 0.1, POWER_W, true, true};  // #32
-  Protocol.InputRegisters[P124_VBAT] =
-      sGrowattModbusReg_t{1013, 0,       SIZE_16BIT, "BatteryVoltage",
-                          0.1,  VOLTAGE, false,      false};  // #33
+  Protocol.InputRegisters[P124_PDISCHARGE] =
+      sGrowattModbusReg_t{1009,    0,    SIZE_32BIT, "DischargePower", 0.1, 0.1,
+                          POWER_W, true, true};  // #31
+  Protocol.InputRegisters[P124_PCHARGE] =
+      sGrowattModbusReg_t{1011, 0,       SIZE_32BIT, "ChargePower", 0.1,
+                          0.1,  POWER_W, true,       true};  // #32
+  Protocol.InputRegisters[P124_VBAT] = sGrowattModbusReg_t{
+      1013,    0,     SIZE_16BIT, "BatteryVoltage", 0.1, 0.1,
+      VOLTAGE, false, false};  // #33
   Protocol.InputRegisters[P124_SOC] = sGrowattModbusReg_t{
-      1014, 0, SIZE_16BIT, "SOC", 1, PRECENTAGE, true, true};  // #34
-  Protocol.InputRegisters[P124_PAC_TO_USER] = sGrowattModbusReg_t{
-      1015, 0, SIZE_32BIT, "ACPowerToUser", 0.1, POWER_W, false, false};  // #35
-  Protocol.InputRegisters[P124_PAC_TO_USER_TOTAL] =
-      sGrowattModbusReg_t{1021, 0,       SIZE_32BIT, "ACPowerToUserTotal",
-                          0.1,  POWER_W, false,      false};  // #36
-  Protocol.InputRegisters[P124_PAC_TO_GRID] = sGrowattModbusReg_t{
-      1023, 0, SIZE_32BIT, "ACPowerToGrid", 0.1, POWER_W, false, false};  // #37
-  Protocol.InputRegisters[P124_PAC_TO_GRID_TOTAL] =
-      sGrowattModbusReg_t{1029, 0,       SIZE_32BIT, "ACPowerToGridTotal",
-                          0.1,  POWER_W, false,      false};  // #38
-  Protocol.InputRegisters[P124_PLOCAL_LOAD] =
-      sGrowattModbusReg_t{1031, 0,       SIZE_32BIT, "INVPowerToLocalLoad",
-                          0.1,  POWER_W, false,      false};  // #39
-  Protocol.InputRegisters[P124_PLOCAL_LOAD_TOTAL] =
-      sGrowattModbusReg_t{1037, 0,       SIZE_32BIT, "INVPowerToLocalLoadTotal",
-                          0.1,  POWER_W, true,       false};  // #40
-  Protocol.InputRegisters[P124_BATTERY_TEMPERATURE] =
-      sGrowattModbusReg_t{1040, 0,           SIZE_16BIT, "BatteryTemperature",
-                          0.1,  TEMPERATURE, true,       true};  // #41
+      1014, 0, SIZE_16BIT, "SOC", 1, 1, PRECENTAGE, true, true};  // #34
+  Protocol.InputRegisters[P124_PAC_TO_USER] =
+      sGrowattModbusReg_t{1015,    0,     SIZE_32BIT, "ACPowerToUser", 0.1, 0.1,
+                          POWER_W, false, false};  // #35
+  Protocol.InputRegisters[P124_PAC_TO_USER_TOTAL] = sGrowattModbusReg_t{
+      1021,    0,     SIZE_32BIT, "ACPowerToUserTotal", 0.1, 0.1,
+      POWER_W, false, false};  // #36
+  Protocol.InputRegisters[P124_PAC_TO_GRID] =
+      sGrowattModbusReg_t{1023,    0,     SIZE_32BIT, "ACPowerToGrid", 0.1, 0.1,
+                          POWER_W, false, false};  // #37
+  Protocol.InputRegisters[P124_PAC_TO_GRID_TOTAL] = sGrowattModbusReg_t{
+      1029,    0,     SIZE_32BIT, "ACPowerToGridTotal", 0.1, 0.1,
+      POWER_W, false, false};  // #38
+  Protocol.InputRegisters[P124_PLOCAL_LOAD] = sGrowattModbusReg_t{
+      1031,    0,     SIZE_32BIT, "INVPowerToLocalLoad", 0.1, 0.1,
+      POWER_W, false, false};  // #39
+  Protocol.InputRegisters[P124_PLOCAL_LOAD_TOTAL] = sGrowattModbusReg_t{
+      1037,    0,    SIZE_32BIT, "INVPowerToLocalLoadTotal", 0.1, 0.1,
+      POWER_W, true, false};  // #40
+  Protocol.InputRegisters[P124_BATTERY_TEMPERATURE] = sGrowattModbusReg_t{
+      1040,        0,    SIZE_16BIT, "BatteryTemperature", 0.1, 0.1,
+      TEMPERATURE, true, true};  // #41
   Protocol.InputRegisters[P124_BATTERY_STATE] = sGrowattModbusReg_t{
-      1041, 0, SIZE_16BIT, "BatteryState", 1, NONE, true, false};  // #42
+      1041, 0, SIZE_16BIT, "BatteryState", 1, 1, NONE, true, false};  // #42
 
-  Protocol.InputRegisters[P124_ETOUSER_TODAY] =
-      sGrowattModbusReg_t{1044, 0,         SIZE_32BIT, "EnergyToUserToday",
-                          0.1,  POWER_KWH, true,       false};  // #43
-  Protocol.InputRegisters[P124_ETOUSER_TOTAL] =
-      sGrowattModbusReg_t{1046, 0,         SIZE_32BIT, "EnergyToUserTotal",
-                          0.1,  POWER_KWH, true,       false};  // #44
-  Protocol.InputRegisters[P124_ETOGRID_TODAY] =
-      sGrowattModbusReg_t{1048, 0,         SIZE_32BIT, "EnergyToGridToday",
-                          0.1,  POWER_KWH, true,       false};  // #45
-  Protocol.InputRegisters[P124_ETOGRID_TOTAL] =
-      sGrowattModbusReg_t{1050, 0,         SIZE_32BIT, "EnergyToGridTotal",
-                          0.1,  POWER_KWH, true,       false};  // #46
-  Protocol.InputRegisters[P124_EDISCHARGE_TODAY] =
-      sGrowattModbusReg_t{1052, 0,         SIZE_32BIT, "DischargeEnergyToday",
-                          0.1,  POWER_KWH, true,       false};  // #47
-  Protocol.InputRegisters[P124_EDISCHARGE_TOTAL] =
-      sGrowattModbusReg_t{1054, 0,         SIZE_32BIT, "DischargeEnergyTotal",
-                          0.1,  POWER_KWH, true,       false};  // #48
-  Protocol.InputRegisters[P124_ECHARGE_TODAY] =
-      sGrowattModbusReg_t{1056, 0,         SIZE_32BIT, "ChargeEnergyToday",
-                          0.1,  POWER_KWH, true,       false};  // #49
-  Protocol.InputRegisters[P124_ECHARGE_TOTAL] =
-      sGrowattModbusReg_t{1058, 0,         SIZE_32BIT, "ChargeEnergyTotal",
-                          0.1,  POWER_KWH, true,       false};  // #50
-  Protocol.InputRegisters[P124_ETOLOCALLOAD_TODAY] =
-      sGrowattModbusReg_t{1060, 0,         SIZE_32BIT, "LocalLoadEnergyToday",
-                          0.1,  POWER_KWH, true,       false};  // #51
-  Protocol.InputRegisters[P124_ETOLOCALLOAD_TOTAL] =
-      sGrowattModbusReg_t{1062, 0,         SIZE_32BIT, "LocalLoadEnergyTotal",
-                          0.1,  POWER_KWH, true,       false};  // #52
+  Protocol.InputRegisters[P124_ETOUSER_TODAY] = sGrowattModbusReg_t{
+      1044,      0,    SIZE_32BIT, "EnergyToUserToday", 0.1, 0.1,
+      POWER_KWH, true, false};  // #43
+  Protocol.InputRegisters[P124_ETOUSER_TOTAL] = sGrowattModbusReg_t{
+      1046,      0,    SIZE_32BIT, "EnergyToUserTotal", 0.1, 0.1,
+      POWER_KWH, true, false};  // #44
+  Protocol.InputRegisters[P124_ETOGRID_TODAY] = sGrowattModbusReg_t{
+      1048,      0,    SIZE_32BIT, "EnergyToGridToday", 0.1, 0.1,
+      POWER_KWH, true, false};  // #45
+  Protocol.InputRegisters[P124_ETOGRID_TOTAL] = sGrowattModbusReg_t{
+      1050,      0,    SIZE_32BIT, "EnergyToGridTotal", 0.1, 0.1,
+      POWER_KWH, true, false};  // #46
+  Protocol.InputRegisters[P124_EDISCHARGE_TODAY] = sGrowattModbusReg_t{
+      1052,      0,    SIZE_32BIT, "DischargeEnergyToday", 0.1, 0.1,
+      POWER_KWH, true, false};  // #47
+  Protocol.InputRegisters[P124_EDISCHARGE_TOTAL] = sGrowattModbusReg_t{
+      1054,      0,    SIZE_32BIT, "DischargeEnergyTotal", 0.1, 0.1,
+      POWER_KWH, true, false};  // #48
+  Protocol.InputRegisters[P124_ECHARGE_TODAY] = sGrowattModbusReg_t{
+      1056,      0,    SIZE_32BIT, "ChargeEnergyToday", 0.1, 0.1,
+      POWER_KWH, true, false};  // #49
+  Protocol.InputRegisters[P124_ECHARGE_TOTAL] = sGrowattModbusReg_t{
+      1058,      0,    SIZE_32BIT, "ChargeEnergyTotal", 0.1, 0.1,
+      POWER_KWH, true, false};  // #50
+  Protocol.InputRegisters[P124_ETOLOCALLOAD_TODAY] = sGrowattModbusReg_t{
+      1060,      0,    SIZE_32BIT, "LocalLoadEnergyToday", 0.1, 0.1,
+      POWER_KWH, true, false};  // #51
+  Protocol.InputRegisters[P124_ETOLOCALLOAD_TOTAL] = sGrowattModbusReg_t{
+      1062,      0,    SIZE_32BIT, "LocalLoadEnergyTotal", 0.1, 0.1,
+      POWER_KWH, true, false};  // #52
   // FEAGMENT 3: END
 
   Protocol.InputFragmentCount = 3;

--- a/SRC/ShineWiFi-ModBus/Growatt305.cpp
+++ b/SRC/ShineWiFi-ModBus/Growatt305.cpp
@@ -8,29 +8,35 @@ void init_growatt305(sProtocolDefinition_t &Protocol) {
   // address, value, size, name, multiplier, unit, frontend, plot
   // FEAGMENT 1: BEGIN
   Protocol.InputRegisters[P305_I_STATUS] = sGrowattModbusReg_t{
-      0, 0, SIZE_16BIT, "InverterStatus", 1, NONE, true, false};  // #1
+      0, 0, SIZE_16BIT, "InverterStatus", 1, 1, NONE, true, false};  // #1
   Protocol.InputRegisters[P305_DC_POWER] = sGrowattModbusReg_t{
-      1, 0, SIZE_32BIT, "DcPower", 0.1, POWER_W, true, true};  // #2
+      1, 0, SIZE_32BIT, "DcPower", 0.1, 0.1, POWER_W, true, true};  // #2
   Protocol.InputRegisters[P305_DC_VOLTAGE] = sGrowattModbusReg_t{
-      3, 0, SIZE_16BIT, "DcVoltage", 0.1, VOLTAGE, true, false};  // #3
-  Protocol.InputRegisters[P305_DC_INPUT_CURRENT] = sGrowattModbusReg_t{
-      4, 0, SIZE_16BIT, "DcInputCurrent", 0.1, CURRENT, true, false};  // #4
-  Protocol.InputRegisters[P305_AC_FREQUENCY] = sGrowattModbusReg_t{
-      13, 0, SIZE_16BIT, "AcFrequency", 0.01, FREQUENCY, true, false};  // #5
+      3, 0, SIZE_16BIT, "DcVoltage", 0.1, 0.1, VOLTAGE, true, false};  // #3
+  Protocol.InputRegisters[P305_DC_INPUT_CURRENT] =
+      sGrowattModbusReg_t{4,       0,    SIZE_16BIT, "DcInputCurrent", 0.1, 0.1,
+                          CURRENT, true, false};  // #4
+  Protocol.InputRegisters[P305_AC_FREQUENCY] =
+      sGrowattModbusReg_t{13,   0,         SIZE_16BIT, "AcFrequency", 0.01,
+                          0.01, FREQUENCY, true,       false};  // #5
   Protocol.InputRegisters[P305_AC_VOLTAGE] = sGrowattModbusReg_t{
-      14, 0, SIZE_16BIT, "AcVoltage", 0.1, VOLTAGE, true, false};  // #6
+      14, 0, SIZE_16BIT, "AcVoltage", 0.1, 0.1, VOLTAGE, true, false};  // #6
   Protocol.InputRegisters[P305_AC_OUTPUT_CURRENT] = sGrowattModbusReg_t{
-      15, 0, SIZE_16BIT, "AcOutputCurrent", 0.1, CURRENT, true, false};  // #7
+      15,      0,    SIZE_16BIT, "AcOutputCurrent", 0.1, 0.1,
+      CURRENT, true, false};  // #7
   Protocol.InputRegisters[P305_AC_POWER] = sGrowattModbusReg_t{
-      16, 0, SIZE_32BIT, "AcPower", 0.1, POWER_W, true, true};  // #8
-  Protocol.InputRegisters[P305_ENERGY_TODAY] = sGrowattModbusReg_t{
-      26, 0, SIZE_32BIT, "EnergyToday", 0.1, POWER_KWH, true, false};  // #9
-  Protocol.InputRegisters[P305_ENERGY_TOTAL] = sGrowattModbusReg_t{
-      28, 0, SIZE_32BIT, "EnergyTotal", 0.1, POWER_KWH, true, false};  // #10
+      16, 0, SIZE_32BIT, "AcPower", 0.1, 0.1, POWER_W, true, true};  // #8
+  Protocol.InputRegisters[P305_ENERGY_TODAY] =
+      sGrowattModbusReg_t{26,  0,         SIZE_32BIT, "EnergyToday", 0.1,
+                          0.1, POWER_KWH, true,       false};  // #9
+  Protocol.InputRegisters[P305_ENERGY_TOTAL] =
+      sGrowattModbusReg_t{28,  0,         SIZE_32BIT, "EnergyTotal", 0.1,
+                          0.1, POWER_KWH, true,       false};  // #10
   Protocol.InputRegisters[P305_OPERATING_TIME] = sGrowattModbusReg_t{
-      30, 0, SIZE_32BIT, "OperatingTime", 0.5, SECONDS, true, false};  // #11
-  Protocol.InputRegisters[P305_TEMPERATURE] = sGrowattModbusReg_t{
-      32, 0, SIZE_16BIT, "Temperature", 0.1, TEMPERATURE, true, false};  // #12
+      30, 0, SIZE_32BIT, "OperatingTime", 0.5, 1, SECONDS, true, false};  // #11
+  Protocol.InputRegisters[P305_TEMPERATURE] =
+      sGrowattModbusReg_t{32,  0,           SIZE_16BIT, "Temperature", 0.1,
+                          0.1, TEMPERATURE, true,       false};  // #12
 
   Protocol.InputFragmentCount = 1;
   Protocol.InputReadFragments[0] = sGrowattReadFragment_t{0, 33};

--- a/SRC/ShineWiFi-ModBus/GrowattSPF.cpp
+++ b/SRC/ShineWiFi-ModBus/GrowattSPF.cpp
@@ -11,59 +11,69 @@ void init_growattSPF(sProtocolDefinition_t &Protocol) {
   Protocol.InputRegisterCount = 27;
   // address, value, size, name, multiplier, unit, frontend, plot
   Protocol.InputRegisters[SPF_I_STATUS] = sGrowattModbusReg_t{
-      0, 0, SIZE_16BIT, "InverterStatus", 1, NONE, true, false};  // #1
+      0, 0, SIZE_16BIT, "InverterStatus", 1, 1, NONE, true, false};  // #1
   Protocol.InputRegisters[SPF_PV1_V] = sGrowattModbusReg_t{
-      1, 0, SIZE_16BIT, "PV1Voltage", 0.1, VOLTAGE, true, false};  // #2
+      1, 0, SIZE_16BIT, "PV1Voltage", 0.1, 0.1, VOLTAGE, true, false};  // #2
   Protocol.InputRegisters[SPF_PV2_V] = sGrowattModbusReg_t{
-      2, 0, SIZE_16BIT, "PV2Voltage", 0.1, VOLTAGE, true, false};  // #3
+      2, 0, SIZE_16BIT, "PV2Voltage", 0.1, 0.1, VOLTAGE, true, false};  // #3
   Protocol.InputRegisters[SPF_PV1_CHGW] = sGrowattModbusReg_t{
-      3, 0, SIZE_32BIT, "PV1ChargePwr", 0.1, POWER_W, true, false};  // #4
+      3, 0, SIZE_32BIT, "PV1ChargePwr", 0.1, 0.1, POWER_W, true, false};  // #4
   Protocol.InputRegisters[SPF_PV2_CHGW] = sGrowattModbusReg_t{
-      5, 0, SIZE_32BIT, "PV2ChargePwr", 0.1, POWER_W, true, false};  // #5
+      5, 0, SIZE_32BIT, "PV2ChargePwr", 0.1, 0.1, POWER_W, true, false};  // #5
   Protocol.InputRegisters[SPF_BUCK1_I] = sGrowattModbusReg_t{
-      7, 0, SIZE_16BIT, "Buck1Current", 0.1, CURRENT, true, false};  // #6
+      7, 0, SIZE_16BIT, "Buck1Current", 0.1, 0.1, CURRENT, true, false};  // #6
   Protocol.InputRegisters[SPF_BUCK2_I] = sGrowattModbusReg_t{
-      8, 0, SIZE_16BIT, "Buck2Current", 0.1, CURRENT, true, false};  // #7
+      8, 0, SIZE_16BIT, "Buck2Current", 0.1, 0.1, CURRENT, true, false};  // #7
   Protocol.InputRegisters[SPF_OUT_PWR] = sGrowattModbusReg_t{
-      9, 0, SIZE_32BIT, "OutActivePwr", 0.1, POWER_W, true, true};  // #8
+      9, 0, SIZE_32BIT, "OutActivePwr", 0.1, 0.1, POWER_W, true, true};  // #8
   Protocol.InputRegisters[SPF_OUT_VA] = sGrowattModbusReg_t{
-      11, 0, SIZE_32BIT, "OutVA", 0.1, VA, true, false};  // #9
+      11, 0, SIZE_32BIT, "OutVA", 0.1, 0.1, VA, true, false};  // #9
   Protocol.InputRegisters[SPF_AC_CHGPWR] = sGrowattModbusReg_t{
-      13, 0, SIZE_32BIT, "ACChargePwr", 0.1, POWER_W, true, true};  // #10
+      13, 0, SIZE_32BIT, "ACChargePwr", 0.1, 0.1, POWER_W, true, true};  // #10
   Protocol.InputRegisters[SPF_AC_CHGVA] = sGrowattModbusReg_t{
-      15, 0, SIZE_32BIT, "ACChargeVA", 0.1, VA, true, false};  // #11
-  Protocol.InputRegisters[SPF_BATT_V] = sGrowattModbusReg_t{
-      17, 0, SIZE_16BIT, "BattVoltage", 0.01, VOLTAGE, true, false};  // #12
+      15, 0, SIZE_32BIT, "ACChargeVA", 0.1, 0.1, VA, true, false};  // #11
+  Protocol.InputRegisters[SPF_BATT_V] =
+      sGrowattModbusReg_t{17,   0,       SIZE_16BIT, "BattVoltage", 0.01,
+                          0.01, VOLTAGE, true,       false};  // #12
   Protocol.InputRegisters[SPF_BATT_SOC] = sGrowattModbusReg_t{
-      18, 0, SIZE_16BIT, "BattSOC", 1, PRECENTAGE, true, false};  // #13
+      18, 0, SIZE_16BIT, "BattSOC", 1, 1, PRECENTAGE, true, false};  // #13
   Protocol.InputRegisters[SPF_BUS_V] = sGrowattModbusReg_t{
-      19, 0, SIZE_16BIT, "BusVoltage", 0.1, VOLTAGE, true, false};  // #14
-  Protocol.InputRegisters[SPF_GRID_V] = sGrowattModbusReg_t{
-      20, 0, SIZE_16BIT, "GridInVoltage", 0.1, VOLTAGE, true, false};  // #15
+      19, 0, SIZE_16BIT, "BusVoltage", 0.1, 0.1, VOLTAGE, true, false};  // #14
+  Protocol.InputRegisters[SPF_GRID_V] =
+      sGrowattModbusReg_t{20,      0,    SIZE_16BIT, "GridInVoltage", 0.1, 0.1,
+                          VOLTAGE, true, false};  // #15
   Protocol.InputRegisters[SPF_LINE_F] = sGrowattModbusReg_t{
-      21, 0, SIZE_16BIT, "LineFrequency", 0.01, FREQUENCY, true, false};  // #16
+      21,        0,    SIZE_16BIT, "LineFrequency", 0.01, 0.01,
+      FREQUENCY, true, false};  // #16
   Protocol.InputRegisters[SPF_OUT_V] = sGrowattModbusReg_t{
-      22, 0, SIZE_16BIT, "OutVoltage", 0.1, VOLTAGE, true, false};  // #17
-  Protocol.InputRegisters[SPF_OUT_F] = sGrowattModbusReg_t{
-      23, 0, SIZE_16BIT, "OutFrequency", 0.01, FREQUENCY, true, false};  // #18
-  Protocol.InputRegisters[SPF_OUT_DCV] = sGrowattModbusReg_t{
-      24, 0, SIZE_16BIT, "OutDCVoltage", 0.1, VOLTAGE, true, false};  // #19
-  Protocol.InputRegisters[SPF_INV_T] = sGrowattModbusReg_t{
-      25, 0, SIZE_16BIT, "InverterTemp", 0.1, TEMPERATURE, true, false};  // #20
-  Protocol.InputRegisters[SPF_DCDC_T] = sGrowattModbusReg_t{
-      26, 0, SIZE_16BIT, "DCDCTemp", 0.1, TEMPERATURE, true, false};  // #21
-  Protocol.InputRegisters[SPF_LOAD] = sGrowattModbusReg_t{
-      27, 0, SIZE_16BIT, "LoadPercent", 0.1, PRECENTAGE, true, false};  // #22
-  Protocol.InputRegisters[SPF_BUCK1_T] = sGrowattModbusReg_t{
-      32, 0, SIZE_16BIT, "Buck1Temp", 0.1, TEMPERATURE, true, false};  // #23
-  Protocol.InputRegisters[SPF_BUCK2_T] = sGrowattModbusReg_t{
-      33, 0, SIZE_16BIT, "Buck2Temp", 0.1, TEMPERATURE, true, false};  // #24
+      22, 0, SIZE_16BIT, "OutVoltage", 0.1, 0.1, VOLTAGE, true, false};  // #17
+  Protocol.InputRegisters[SPF_OUT_F] =
+      sGrowattModbusReg_t{23,   0,         SIZE_16BIT, "OutFrequency", 0.01,
+                          0.01, FREQUENCY, true,       false};  // #18
+  Protocol.InputRegisters[SPF_OUT_DCV] =
+      sGrowattModbusReg_t{24,  0,       SIZE_16BIT, "OutDCVoltage", 0.1,
+                          0.1, VOLTAGE, true,       false};  // #19
+  Protocol.InputRegisters[SPF_INV_T] =
+      sGrowattModbusReg_t{25,  0,           SIZE_16BIT, "InverterTemp", 0.1,
+                          0.1, TEMPERATURE, true,       false};  // #20
+  Protocol.InputRegisters[SPF_DCDC_T] =
+      sGrowattModbusReg_t{26,  0,           SIZE_16BIT, "DCDCTemp", 0.1,
+                          0.1, TEMPERATURE, true,       false};  // #21
+  Protocol.InputRegisters[SPF_LOAD] =
+      sGrowattModbusReg_t{27,  0,          SIZE_16BIT, "LoadPercent", 0.1,
+                          0.1, PRECENTAGE, true,       false};  // #22
+  Protocol.InputRegisters[SPF_BUCK1_T] =
+      sGrowattModbusReg_t{32,  0,           SIZE_16BIT, "Buck1Temp", 0.1,
+                          0.1, TEMPERATURE, true,       false};  // #23
+  Protocol.InputRegisters[SPF_BUCK2_T] =
+      sGrowattModbusReg_t{33,  0,           SIZE_16BIT, "Buck2Temp", 0.1,
+                          0.1, TEMPERATURE, true,       false};  // #24
   Protocol.InputRegisters[SPF_AC_INPWR] = sGrowattModbusReg_t{
-      36, 0, SIZE_32BIT, "ACInPwr", 0.1, POWER_W, true, true};  // #25
+      36, 0, SIZE_32BIT, "ACInPwr", 0.1, 0.1, POWER_W, true, true};  // #25
   Protocol.InputRegisters[SPF_AC_INVA] = sGrowattModbusReg_t{
-      38, 0, SIZE_32BIT, "ACInVA", 0.1, VA, true, false};  // #26
+      38, 0, SIZE_32BIT, "ACInVA", 0.1, 0.1, VA, true, false};  // #26
   Protocol.InputRegisters[SPF_BATT_PWR] = sGrowattModbusReg_t{
-      77, 0, SIZE_32BIT, "BattPwr", 0.1, POWER_W, true, false};  // #27
+      77, 0, SIZE_32BIT, "BattPwr", 0.1, 0.1, POWER_W, true, false};  // #27
 
   Protocol.InputFragmentCount = 2;
   Protocol.InputReadFragments[0] = sGrowattReadFragment_t{0, 40};

--- a/SRC/ShineWiFi-ModBus/GrowattTypes.h
+++ b/SRC/ShineWiFi-ModBus/GrowattTypes.h
@@ -54,6 +54,7 @@ typedef struct {
   RegisterSize_t size;
   char name[64];
   float multiplier;
+  float resolution;
   RegisterUnit_t unit;
   bool frontend;
   bool plot;

--- a/SRC/ShineWiFi-ModBus/ShineMqtt.cpp
+++ b/SRC/ShineWiFi-ModBus/ShineMqtt.cpp
@@ -19,7 +19,7 @@ void ShineMqtt::mqttSetup(const MqttConfig& config) {
 #if ENABLE_REMOTE_DEBUG == 1
   debugV("MqttServer: %s", this->mqttconfig.mqttserver);
   debugV("MqttPort: %d", intPort);
-  debugV("MqttTopic: %s",this->mqttconfig.mqtttopic);
+  debugV("MqttTopic: %s", this->mqttconfig.mqtttopic);
 #endif
   // make sure the packet size is set correctly in the library
   this->mqttclient.setBufferSize(MQTT_MAX_PACKET_SIZE);

--- a/SRC/ShineWiFi-ModBus/ShineMqtt.cpp
+++ b/SRC/ShineWiFi-ModBus/ShineMqtt.cpp
@@ -16,7 +16,11 @@ void ShineMqtt::mqttSetup(const MqttConfig& config) {
   Serial.print(F("MqttTopic: "));
   Serial.println(this->mqttconfig.mqtttopic);
 #endif
-
+#if ENABLE_REMOTE_DEBUG == 1
+  debugV("MqttServer: %s", this->mqttconfig.mqttserver);
+  debugV("MqttPort: %d", intPort);
+  debugV("MqttTopic: %s",this->mqttconfig.mqtttopic);
+#endif
   // make sure the packet size is set correctly in the library
   this->mqttclient.setBufferSize(MQTT_MAX_PACKET_SIZE);
   this->mqttclient.setServer(this->mqttconfig.mqttserver.c_str(), intPort);
@@ -54,6 +58,12 @@ bool ShineMqtt::mqttReconnect() {
     Serial.println(this->mqttconfig.mqtttopic);
     Serial.print("Attempting MQTT connection...");
 #endif
+#if ENABLE_REMOTE_DEBUG == 1
+    debugV("MqttServer: %s", this->mqttconfig.mqttserver);
+    debugV("MqttUser: %s", this->mqttconfig.mqttuser);
+    debugV("MqttTopic: %s", this->mqttconfig.mqtttopic);
+    debugV("Attempting MQTT connection...");
+#endif
 
     // Run only once every 5 seconds
     this->previousConnectTryMillis = millis();
@@ -67,13 +77,21 @@ bool ShineMqtt::mqttReconnect() {
       Serial.println("connected");
       return true;
 #endif
+#if ENABLE_REMOTE_DEBUG == 1
+      debugV("MQTT: connected");
+#endif
     } else {
 #if ENABLE_DEBUG_OUTPUT == 1
       Serial.print("failed, rc=");
       Serial.print(this->mqttclient.state());
       Serial.println(" try again in 5 seconds");
 #endif
-      WEB_DEBUG_PRINT("MQTT Connect failed")
+#if ENABLE_REMOTE_DEBUG == 1
+      debugV("failed, rc=%d", this->mqttclient.state());
+      debugV(" try again in 5 seconds");
+#endif
+
+      DEBUG_PRINT("MQTT Connect failed")
       previousConnectTryMillis = millis();
     }
   }

--- a/SRC/ShineWiFi-ModBus/ShineWiFi-ModBus.ino
+++ b/SRC/ShineWiFi-ModBus/ShineWiFi-ModBus.ino
@@ -146,7 +146,7 @@ void WiFi_Reconnect()
             Serial.println(HOSTNAME);
         #endif
 
-        WEB_DEBUG_PRINT("WiFi reconnected")
+        DEBUG_PRINT("WiFi reconnected")
 
         digitalWrite(LED_RT, 1);
     }
@@ -164,11 +164,11 @@ void InverterReconnect(void)
 
     #if ENABLE_WEB_DEBUG == 1
         if (Inverter.GetWiFiStickType() == ShineWiFi_S)
-            WEB_DEBUG_PRINT("ShineWiFi-S (Serial) found")
+            DEBUG_PRINT("ShineWiFi-S (Serial) found")
         else if (Inverter.GetWiFiStickType() == ShineWiFi_X)
-            WEB_DEBUG_PRINT("ShineWiFi-X (USB) found")
+            DEBUG_PRINT("ShineWiFi-X (USB) found")
         else
-            WEB_DEBUG_PRINT("Error: Unknown Shine Stick")
+            DEBUG_PRINT("Error: Unknown Shine Stick")
     #endif
 }
 
@@ -253,7 +253,7 @@ void setup()
         Serial.begin(115200);
         Serial.println(F("Setup()"));
     #endif
-    WEB_DEBUG_PRINT("Setup()");
+    DEBUG_PRINT("Setup()");
 
     #if ENABLE_DOUBLE_RESET == 1
         drd = new DoubleResetDetector(DRD_TIMEOUT, DRD_ADDRESS);
@@ -341,6 +341,11 @@ void setup()
         httpUpdater.setup(&httpServer, update_path, UPDATE_USER, UPDATE_PASSWORD);
     #endif
     httpServer.begin();
+
+#if ENABLE_REMOTE_DEBUG == 1
+    Debug.begin(HOSTNAME);
+    Debug.setResetCmdEnabled(true);
+#endif
 }
 
 #if MQTT_SUPPORTED == 1
@@ -535,6 +540,10 @@ void loop()
         drd->loop();
     #endif
 
+    #if ENABLE_REMOTE_DEBUG == 1
+        Debug.handle();
+    #endif
+
     long now = millis();
     char readoutSucceeded;
 
@@ -626,7 +635,7 @@ void loop()
                 if (Inverter.ReadData()) // get new data from inverter
                 #endif
                 {
-                    WEB_DEBUG_PRINT("ReadData() successful")
+                    DEBUG_PRINT("ReadData() successful")
                     u16PacketCnt++;
                     u8RetryCounter = NUM_OF_RETRIES;
 
@@ -644,14 +653,14 @@ void loop()
                 }
                 else
                 {
-                    WEB_DEBUG_PRINT("ReadData() NOT successful")
+                    DEBUG_PRINT("ReadData() NOT successful")
                     if (u8RetryCounter)
                     {
                         u8RetryCounter--;
                     }
                     else
                     {
-                        WEB_DEBUG_PRINT("Retry counter\n")
+                        DEBUG_PRINT("Retry counter\n")
                         sprintf(JSONChars, "{\"InverterStatus\": -1 }");
                         #if MQTT_SUPPORTED == 1
                             shineMqtt.mqttPublish(JSONChars);

--- a/SRC/ShineWiFi-ModBus/WebDebug.c
+++ b/SRC/ShineWiFi-ModBus/WebDebug.c
@@ -1,5 +1,0 @@
-#include "WebDebug.h"
-#include <stdint.h>
-
-char acWebDebug[1024] = "";
-uint16_t u16WebMsgNo = 0;

--- a/SRC/ShineWiFi-ModBus/WebDebug.cpp
+++ b/SRC/ShineWiFi-ModBus/WebDebug.cpp
@@ -1,0 +1,12 @@
+#include "Config.h"
+#include "WebDebug.h"
+#include <stdint.h>
+
+#if ENABLE_REMOTE_DEBUG == 1
+  RemoteDebug Debug;
+#endif
+
+#if ENABLE_WEB_DEBUG == 1
+  char acWebDebug[1024] = "";
+  uint16_t u16WebMsgNo = 0;
+#endif

--- a/SRC/ShineWiFi-ModBus/WebDebug.cpp
+++ b/SRC/ShineWiFi-ModBus/WebDebug.cpp
@@ -3,10 +3,10 @@
 #include <stdint.h>
 
 #if ENABLE_REMOTE_DEBUG == 1
-  RemoteDebug Debug;
+RemoteDebug Debug;
 #endif
 
 #if ENABLE_WEB_DEBUG == 1
-  char acWebDebug[1024] = "";
-  uint16_t u16WebMsgNo = 0;
+char acWebDebug[1024] = "";
+uint16_t u16WebMsgNo = 0;
 #endif

--- a/SRC/ShineWiFi-ModBus/WebDebug.h
+++ b/SRC/ShineWiFi-ModBus/WebDebug.h
@@ -1,17 +1,53 @@
 #ifndef _SHINE_WEB_DEBUG_H_
 #define _SHINE_WEB_DEBUG_H_
 
-#if ENABLE_WEB_DEBUG == 1
-extern char acWebDebug[1024];
-extern uint16_t u16WebMsgNo;
-#define WEB_DEBUG_PRINT(s)                                              \
-  {                                                                     \
-    if ((strlen(acWebDebug) + strlen(s) + 50) < sizeof(acWebDebug))     \
-      sprintf(acWebDebug, "%s#%i: %s\n", acWebDebug, u16WebMsgNo++, s); \
-  }
+#include <stdint.h>
+
+#if ENABLE_REMOTE_DEBUG == 1
+  #include "RemoteDebug.h"
+  extern RemoteDebug Debug;
+  #define REMOTE_DEBUG_PRINT(s)                                                 \
+      {                                                                         \
+        if (Debug.isActive(Debug.INFO))                                         \
+            Debug.println(s);                                                   \
+      }
 #else
-#undef WEB_DEBUG_PRINT
-#define WEB_DEBUG_PRINT(s) ;
+  #undef REMOTE_DEBUG_PRINT
+  #define REMOTE_DEBUG_PRINT(s) ;
+#endif
+
+#if ENABLE_WEB_DEBUG == 1
+  extern char acWebDebug[1024];
+  extern uint16_t u16WebMsgNo;
+  #define WEB_DEBUG_PRINT(s)                                                    \
+    {                                                                           \
+      if ((strlen(acWebDebug) + strlen(s) + 50) < sizeof(acWebDebug))           \
+        sprintf(acWebDebug, "%s#%i: %s\n", acWebDebug, u16WebMsgNo++, s);       \
+    }
+#else
+  #undef WEB_DEBUG_PRINT
+  #define WEB_DEBUG_PRINT(s) ;
+#endif
+
+#if (ENABLE_WEB_DEBUG == 1) && (ENABLE_REMOTE_DEBUG == 1)
+  #define DEBUG_PRINT(s)                                                        \
+    {                                                                           \
+      WEB_DEBUG_PRINT(s);                                                       \
+      REMOTE_DEBUG_PRINT(s);                                                    \
+    }
+#elif ENABLE_WEB_DEBUG == 1
+  #define DEBUG_PRINT(s)                                                        \
+    {                                                                           \
+      WEB_DEBUG_PRINT(s);                                                       \
+    }
+#elif ENABLE_REMOTE_DEBUG == 1
+  #define DEBUG_PRINT(s)                                                        \
+    {                                                                           \
+      REMOTE_DEBUG_PRINT(s);                                                    \
+    }
+#else
+  #undef DEBUG_PRINT
+  #define DEBUG_PRINT(s) ;
 #endif
 
 #endif

--- a/SRC/ShineWiFi-ModBus/WebDebug.h
+++ b/SRC/ShineWiFi-ModBus/WebDebug.h
@@ -4,50 +4,45 @@
 #include <stdint.h>
 
 #if ENABLE_REMOTE_DEBUG == 1
-  #include "RemoteDebug.h"
-  extern RemoteDebug Debug;
-  #define REMOTE_DEBUG_PRINT(s)                                                 \
-      {                                                                         \
-        if (Debug.isActive(Debug.INFO))                                         \
-            Debug.println(s);                                                   \
-      }
+#include "RemoteDebug.h"
+extern RemoteDebug Debug;
+#define REMOTE_DEBUG_PRINT(s)                         \
+  {                                                   \
+    if (Debug.isActive(Debug.INFO)) Debug.println(s); \
+  }
 #else
-  #undef REMOTE_DEBUG_PRINT
-  #define REMOTE_DEBUG_PRINT(s) ;
+#undef REMOTE_DEBUG_PRINT
+#define REMOTE_DEBUG_PRINT(s) ;
 #endif
 
 #if ENABLE_WEB_DEBUG == 1
-  extern char acWebDebug[1024];
-  extern uint16_t u16WebMsgNo;
-  #define WEB_DEBUG_PRINT(s)                                                    \
-    {                                                                           \
-      if ((strlen(acWebDebug) + strlen(s) + 50) < sizeof(acWebDebug))           \
-        sprintf(acWebDebug, "%s#%i: %s\n", acWebDebug, u16WebMsgNo++, s);       \
-    }
+extern char acWebDebug[1024];
+extern uint16_t u16WebMsgNo;
+#define WEB_DEBUG_PRINT(s)                                              \
+  {                                                                     \
+    if ((strlen(acWebDebug) + strlen(s) + 50) < sizeof(acWebDebug))     \
+      sprintf(acWebDebug, "%s#%i: %s\n", acWebDebug, u16WebMsgNo++, s); \
+  }
 #else
-  #undef WEB_DEBUG_PRINT
-  #define WEB_DEBUG_PRINT(s) ;
+#undef WEB_DEBUG_PRINT
+#define WEB_DEBUG_PRINT(s) ;
 #endif
 
 #if (ENABLE_WEB_DEBUG == 1) && (ENABLE_REMOTE_DEBUG == 1)
-  #define DEBUG_PRINT(s)                                                        \
-    {                                                                           \
-      WEB_DEBUG_PRINT(s);                                                       \
-      REMOTE_DEBUG_PRINT(s);                                                    \
-    }
+#define DEBUG_PRINT(s)     \
+  {                        \
+    WEB_DEBUG_PRINT(s);    \
+    REMOTE_DEBUG_PRINT(s); \
+  }
 #elif ENABLE_WEB_DEBUG == 1
-  #define DEBUG_PRINT(s)                                                        \
-    {                                                                           \
-      WEB_DEBUG_PRINT(s);                                                       \
-    }
+#define DEBUG_PRINT(s) \
+  { WEB_DEBUG_PRINT(s); }
 #elif ENABLE_REMOTE_DEBUG == 1
-  #define DEBUG_PRINT(s)                                                        \
-    {                                                                           \
-      REMOTE_DEBUG_PRINT(s);                                                    \
-    }
+#define DEBUG_PRINT(s) \
+  { REMOTE_DEBUG_PRINT(s); }
 #else
-  #undef DEBUG_PRINT
-  #define DEBUG_PRINT(s) ;
+#undef DEBUG_PRINT
+#define DEBUG_PRINT(s) ;
 #endif
 
 #endif

--- a/platformio.ini
+++ b/platformio.ini
@@ -30,6 +30,7 @@ lib_deps =
     https://github.com/tzapu/WiFiManager#94bb90322bf85de2c9ec592858f20643161bc11f
     https://github.com/khoih-prog/ESP_DoubleResetDetector#bce10ef01f3d4864a07ef31fdec2ad65adb3e5b8
     https://github.com/bblanchon/ArduinoJson#67b6797b6d19e944b01213926872f955f4b9d54d
+    https://github.com/ktos/RemoteDebug#bf8e35e5a71a8d51593dff5b6f6c62aa18d83b67
 
 [env:nodemcu-32s]
 platform = espressif32
@@ -44,6 +45,7 @@ lib_deps =
     https://github.com/tobiasfaust/ESPHTTPUpdateServer#9546fdadf688d782b80745cdadf986ba1c441c04
     https://github.com/khoih-prog/ESP_DoubleResetDetector#bce10ef01f3d4864a07ef31fdec2ad65adb3e5b8
     https://github.com/bblanchon/ArduinoJson#67b6797b6d19e944b01213926872f955f4b9d54d
+    https://github.com/ktos/RemoteDebug#bf8e35e5a71a8d51593dff5b6f6c62aa18d83b67
 lib_ignore=LittleFS_esp32
 
 [env:lolin32]
@@ -59,4 +61,5 @@ lib_deps =
     https://github.com/tobiasfaust/ESPHTTPUpdateServer#9546fdadf688d782b80745cdadf986ba1c441c04
     https://github.com/khoih-prog/ESP_DoubleResetDetector#bce10ef01f3d4864a07ef31fdec2ad65adb3e5b8
     https://github.com/bblanchon/ArduinoJson#67b6797b6d19e944b01213926872f955f4b9d54d
+    https://github.com/ktos/RemoteDebug#bf8e35e5a71a8d51593dff5b6f6c62aa18d83b67
 lib_ignore=LittleFS_esp32


### PR DESCRIPTION
For Debugging purpose I use RemoteDebug. This is a "telnet Console/Debugger". You can found further information on the project site (https://github.com/ktos/RemoteDebug).

The origin project https://github.com/JoaoLopesF/RemoteDebug is no longer maintained and requires a wrong header. So I use the fork from ktos.

By default, this is turned off and can be enabled in the config file.


I had to change Webdebug.c to a cpp file (because RemoteDebug is written in CPP). I think this shouldn't be a problem.