### PR TITLE
allow disabling of ap button pressed

### DIFF
--- a/SRC/ShineWiFi-ModBus/ShineWiFi-ModBus.ino
+++ b/SRC/ShineWiFi-ModBus/ShineWiFi-ModBus.ino
@@ -72,7 +72,9 @@ e.g. C:\Users\<username>\AppData\Local\Temp\arduino_build_533155
 Growatt Inverter;
 bool StartedConfigAfterBoot = false;
 
+#ifdef AP_BUTTON_PRESSED
 byte btnPressed = 0;
+#endif
 
 #define NUM_OF_RETRIES 5
 char u8RetryCounter = NUM_OF_RETRIES;
@@ -538,6 +540,7 @@ void loop()
     long now = millis();
     char readoutSucceeded;
 
+#ifdef AP_BUTTON_PRESSED
     if ((now - ButtonTimer) > BUTTON_TIMER)
     {
         ButtonTimer = now;
@@ -564,6 +567,7 @@ void loop()
             btnPressed = 0;
         }
     }
+#endif
 
     if (StartedConfigAfterBoot == true)
     {


### PR DESCRIPTION
It would be good, if it's possible to disable this functionallity. Espacially because the default put my Lolin32 in repeatingly rebooting and reconfiguring.

Tested by compiling and on a lolin32 board working on my MID 30k.