### PR TITLE
disable Comment Warning for multiline comments

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -15,7 +15,9 @@ src_dir = SRC/ShineWiFi-ModBus
 [env]
 monitor_speed = 115200
 upload_speed = 921600
-build_flags = "-D MQTT_MAX_PACKET_SIZE=2048"
+build_flags = 
+    "-D MQTT_MAX_PACKET_SIZE=2048"
+    "-Wno-comment"
 
 [env:ShineWifiX]
 platform = espressif8266
@@ -31,8 +33,8 @@ lib_deps =
     https://github.com/khoih-prog/ESP_DoubleResetDetector#bce10ef01f3d4864a07ef31fdec2ad65adb3e5b8
     https://github.com/bblanchon/ArduinoJson#67b6797b6d19e944b01213926872f955f4b9d54d
 build_flags =
-  ${env.build_flags}
-  '-DAP_BUTTON_PRESSED=analogRead\(A0\)\<50'
+    ${env.build_flags}
+    '-DAP_BUTTON_PRESSED=analogRead\(A0\)\<50'
 
 [env:nodemcu-32s]
 platform = espressif32


### PR DESCRIPTION
Disables the buildwarning for line 41-45 in Config.h(.example).