### PR TITLE
change battery temperature scale

### DIFF
--- a/SRC/ShineWiFi-ModBus/Growatt124.cpp
+++ b/SRC/ShineWiFi-ModBus/Growatt124.cpp
@@ -135,7 +135,7 @@ void init_growatt124(sProtocolDefinition_t &Protocol) {
       1037,    0,    SIZE_32BIT, "INVPowerToLocalLoadTotal", 0.1, 0.1,
       POWER_W, true, false};  // #40
   Protocol.InputRegisters[P124_BATTERY_TEMPERATURE] = sGrowattModbusReg_t{
-      1040,        0,    SIZE_16BIT, "BatteryTemperature", 0.1, 0.1,
+      1040,        0,    SIZE_16BIT, "BatteryTemperature", 1, 1,
       TEMPERATURE, true, true};  // #41
   Protocol.InputRegisters[P124_BATTERY_STATE] = sGrowattModbusReg_t{
       1041, 0, SIZE_16BIT, "BatteryState", 1, 1, NONE, true, false};  // #42


### PR DESCRIPTION
Hi Again,

I am checking the Values and the Temperature of my Battery pack was not showing in the right scale.
The Problem is that the Datasheet shows that the Temperature has a scale of 0.1, but this is not right (check screenshots) it musst be 1.0.
I change it and test it on my SPH4600 with Growatt ARK LV Battery pack.

ID1040 (Battery Temperature)

<img width="422" alt="Screenshot 2023-04-16 at 21 23 20" src="https://user-images.githubusercontent.com/20142175/232337789-c830e5cc-875d-4def-98b5-97f0cd6c7c90.png">
<img width="869" alt="Screenshot 2023-04-16 at 21 23 32" src="https://user-images.githubusercontent.com/20142175/232337791-72aa48b2-4e67-41f5-86f5-d7bb322d7ab4.png">

That the Battery temperature is 1.8° is not possible due the actual Temperature ;)
I also read out ID1089 which is the actual BMS Temperature (same result ->18)

Regards 