### PR TITLE
Add v124 AC charging properties

### DIFF
--- a/SRC/ShineWiFi-ModBus/Growatt124.cpp
+++ b/SRC/ShineWiFi-ModBus/Growatt124.cpp
@@ -6,9 +6,9 @@
 // one read!
 void init_growatt124(sProtocolDefinition_t &Protocol) {
   // definition of input registers
-  Protocol.InputRegisterCount = 52;
+  Protocol.InputRegisterCount = 54;
   // address, value, size, name, multiplier, unit, frontend, plot
-  // FEAGMENT 1: BEGIN
+  // FRAGMENT 1: BEGIN
   Protocol.InputRegisters[P124_I_STATUS] = sGrowattModbusReg_t{
       0, 0, SIZE_16BIT, "InverterStatus", 1, 1, NONE, true, false};  // #1
   Protocol.InputRegisters[P124_INPUT_POWER] = sGrowattModbusReg_t{
@@ -64,9 +64,9 @@ void init_growatt124(sProtocolDefinition_t &Protocol) {
   Protocol.InputRegisters[P124_PAC3] = sGrowattModbusReg_t{
       48, 0,     SIZE_32BIT, "L3ThreePhaseGridOutputPower", 0.1, 0.1,
       VA, false, false};  // #19
-  // FEAGMENT 1: END
+  // FRAGMENT 1: END
 
-  // FEAGMENT 2: BEGIN
+  // FRAGMENT 2: BEGIN
   Protocol.InputRegisters[P124_EAC_TODAY] = sGrowattModbusReg_t{
       53,        0,    SIZE_32BIT, "TodayGenerateEnergy", 0.1, 0.1,
       POWER_KWH, true, false};  // #20
@@ -102,9 +102,9 @@ void init_growatt124(sProtocolDefinition_t &Protocol) {
   Protocol.InputRegisters[P124_TEMP3] = sGrowattModbusReg_t{
       95,          0,     SIZE_16BIT, "BoostTemperature", 0.1, 0.1,
       TEMPERATURE, false, false};  // #30
-  // FEAGMENT 2: END
+  // FRAGMENT 2: END
 
-  // FEAGMENT 3: BEGIN
+  // FRAGMENT 3: BEGIN
   Protocol.InputRegisters[P124_PDISCHARGE] =
       sGrowattModbusReg_t{1009,    0,    SIZE_32BIT, "DischargePower", 0.1, 0.1,
                           POWER_W, true, true};  // #31
@@ -170,12 +170,22 @@ void init_growatt124(sProtocolDefinition_t &Protocol) {
   Protocol.InputRegisters[P124_ETOLOCALLOAD_TOTAL] = sGrowattModbusReg_t{
       1062,      0,    SIZE_32BIT, "LocalLoadEnergyTotal", 0.1, 0.1,
       POWER_KWH, true, false};  // #52
-  // FEAGMENT 3: END
+  // FRAGMENT 3: END
 
-  Protocol.InputFragmentCount = 3;
+  // FRAGMENT 4: START
+  Protocol.InputRegisters[P124_ACCHARGE_TODAY] = sGrowattModbusReg_t{
+      1124,      0,    SIZE_32BIT, "ACChargeEnergyToday", 0.1, 0.1,
+      POWER_KWH, true, false};  // #53
+  Protocol.InputRegisters[P124_ACCHARGE_TOTAL] = sGrowattModbusReg_t{
+      1126,      0,    SIZE_32BIT, "ACChargeEnergyTotal", 0.1, 0.1,
+      POWER_KWH, true, false};  // #54
+  // FRAGMENT 4: END
+
+  Protocol.InputFragmentCount = 4;
   Protocol.InputReadFragments[0] = sGrowattReadFragment_t{0, 50};
   Protocol.InputReadFragments[1] = sGrowattReadFragment_t{53, 43};
   Protocol.InputReadFragments[2] = sGrowattReadFragment_t{1009, 55};
+  Protocol.InputReadFragments[3] = sGrowattReadFragment_t{1124, 4};
 
   Protocol.HoldingRegisterCount = 0;
   Protocol.HoldingFragmentCount = 0;

--- a/SRC/ShineWiFi-ModBus/Growatt124.h
+++ b/SRC/ShineWiFi-ModBus/Growatt124.h
@@ -57,6 +57,8 @@ typedef enum {
   P124_ECHARGE_TOTAL,
   P124_ETOLOCALLOAD_TODAY,
   P124_ETOLOCALLOAD_TOTAL,
+  P124_ACCHARGE_TODAY,
+  P124_ACCHARGE_TOTAL,
 } eP124InputRegisters_t;
 
 void init_growatt124(sProtocolDefinition_t &Protocol);

--- a/SRC/ShineWiFi-ModBus/Growatt305.cpp
+++ b/SRC/ShineWiFi-ModBus/Growatt305.cpp
@@ -6,7 +6,7 @@ void init_growatt305(sProtocolDefinition_t &Protocol) {
   // definition of input registers
   Protocol.InputRegisterCount = 12;
   // address, value, size, name, multiplier, unit, frontend, plot
-  // FEAGMENT 1: BEGIN
+  // FRAGMENT 1: BEGIN
   Protocol.InputRegisters[P305_I_STATUS] = sGrowattModbusReg_t{
       0, 0, SIZE_16BIT, "InverterStatus", 1, 1, NONE, true, false};  // #1
   Protocol.InputRegisters[P305_DC_POWER] = sGrowattModbusReg_t{


### PR DESCRIPTION
Adds two new properties to the v124 spec

- `ACChargeEnergyToday` based on input register 1124, described as "AC Charge Energy Today H" / "Energy today" in spec
- `ACChargeEnergyTotal` based on input register 1126, described as "AC Charge Energy Total H" / "Energy total" in spec

These match up with the `eacharge_today` and `eacharge_total` values from the original firmware.

I've also fixed a typo in a few places `FEAGMENT` -> `FRAGMENT`.

![image](https://github.com/otti/Growatt_ShineWiFi-S/assets/2363642/4afd8926-5eb2-469b-a717-4d44d6593d89)

I wasn't sure if I should make a new fragment or increase the range of the existing fragment 3, but figured it would be safest to make a new one. I am also not sure if I needed to put the size of the fragment as 2 or 3 so went with 3 just in case. Happy to modify these if there is a better way.