### PR TITLE
Add Shine WiFi-S environment to PlatformIO

### DIFF
--- a/.github/workflows/platformio.yaml
+++ b/.github/workflows/platformio.yaml
@@ -37,12 +37,13 @@ jobs:
       run: |
         cp "SRC/ShineWiFi-ModBus/Config.h.example" "SRC/ShineWiFi-ModBus/Config.h"
     - name: Run PlatformIO
-      run: pio run -e ShineWifiX -e lolin32 -e nodemcu-32s -e d1
+      run: pio run -e ShineWifiX -e ShineWifiS -e lolin32 -e nodemcu-32s -e d1
     - name: Adjust firmware filename
       run: |
         mkdir release
         mv .pio/build/lolin32/firmware.bin release/firmware-lolin32.bin
         mv .pio/build/ShineWifiX/firmware.bin release/firmware-ShineWifiX.bin
+        mv .pio/build/ShineWifiS/firmware.bin release/firmware-ShineWifiS.bin
         mv .pio/build/nodemcu-32s/firmware.bin release/firmware-nodemcu-32s.bin
         mv .pio/build/d1/firmware.bin release/firmware-d1.bin
     - name: Release

--- a/platformio.ini
+++ b/platformio.ini
@@ -51,6 +51,7 @@ lib_deps =
     https://github.com/tzapu/WiFiManager#94bb90322bf85de2c9ec592858f20643161bc11f
     https://github.com/khoih-prog/ESP_DoubleResetDetector#bce10ef01f3d4864a07ef31fdec2ad65adb3e5b8
     https://github.com/bblanchon/ArduinoJson#67b6797b6d19e944b01213926872f955f4b9d54d
+    https://github.com/dirkx/tee-log.git
 build_flags =
     ${env.build_flags}
     "-D MQTT_MAX_PACKET_SIZE=2048"    

--- a/platformio.ini
+++ b/platformio.ini
@@ -8,11 +8,7 @@
 ; Please visit documentation for the other options and examples
 ; https://docs.platformio.org/page/projectconf.html
 [platformio]
-default_envs = ShineWifiX
-#default_envs = d1
-#default_envs = nodemcu-32s
-#default_envs = lolin32
-
+default_envs = ShineWifiX, ShineWifiS, nodemcu-32s, lolin32, d1
 src_dir = SRC/ShineWiFi-ModBus
 
 [env]
@@ -40,6 +36,25 @@ build_flags =
     ${env.build_flags}
     "-D MQTT_MAX_PACKET_SIZE=2048"
     "-D ENABLE_AP_BUTTON=1"
+
+[env:ShineWifiS]
+platform = espressif8266
+board = esp12e
+framework = arduino
+lib_ldf_mode = deep+
+lib_deps =
+    ArduinoOTA
+    knolleary/PubSubClient@^2.8
+    4-20ma/ModbusMaster@^2.0.1
+    bluemurder/ESP8266-ping@^2.0.1
+    vshymanskyy/Preferences@2.1.0
+    https://github.com/tzapu/WiFiManager#94bb90322bf85de2c9ec592858f20643161bc11f
+    https://github.com/khoih-prog/ESP_DoubleResetDetector#bce10ef01f3d4864a07ef31fdec2ad65adb3e5b8
+    https://github.com/bblanchon/ArduinoJson#67b6797b6d19e944b01213926872f955f4b9d54d
+build_flags =
+    ${env.build_flags}
+    "-D MQTT_MAX_PACKET_SIZE=2048"    
+    "-D ENABLE_AP_BUTTON=1"
     
 [env:d1]
 platform = espressif8266
@@ -61,7 +76,6 @@ build_flags =
     "-D MQTT_MAX_PACKET_SIZE=2048"
     "-D ENABLE_AP_BUTTON=0"    
     
-
 [env:nodemcu-32s]
 platform = espressif32
 board = nodemcu-32s


### PR DESCRIPTION
This adds a new environment to the platformio.ini file for the Shine WiFi-S monitor.

I have also added the esp8266 exception decoder monitor, which will automatically decode exceptions when debugging.

I am using this the resulting build successfully on my Shine WiFi-S stick.