### PR TITLE
Add MQTT API

### DIFF
--- a/SRC/ShineWiFi-ModBus/Growatt120.cpp
+++ b/SRC/ShineWiFi-ModBus/Growatt120.cpp
@@ -1,5 +1,6 @@
 #include "Arduino.h"
 
+#include "Growatt.h"
 #include "Growatt120.h"
 
 // Supported inverters:
@@ -13,7 +14,7 @@
 // - Storage(SPA Type)
 // - Storage(SPH Type)
 
-void init_growatt120(sProtocolDefinition_t &Protocol) {
+void init_growatt120(sProtocolDefinition_t& Protocol, Growatt& inverter) {
   // definition of input registers
   Protocol.InputRegisterCount = eP120InputRegisters_t::LASTInput;
   Protocol.InputFragmentCount = 3;

--- a/SRC/ShineWiFi-ModBus/Growatt120.h
+++ b/SRC/ShineWiFi-ModBus/Growatt120.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "Arduino.h"
+#include "Growatt.h"
 #include "GrowattTypes.h"
 
 // Growatt modbus protocol version 1.20
@@ -86,4 +87,4 @@ typedef enum {
   LASTHolding
 } eP120HoldingRegisters_t;
 
-void init_growatt120(sProtocolDefinition_t &Protocol);
+void init_growatt120(sProtocolDefinition_t &Protocol, Growatt &inverter);

--- a/SRC/ShineWiFi-ModBus/Growatt124.h
+++ b/SRC/ShineWiFi-ModBus/Growatt124.h
@@ -1,6 +1,8 @@
 #pragma once
 
 #include "Arduino.h"
+
+#include "Growatt.h"
 #include "GrowattTypes.h"
 
 // Growatt modbus protocol version 1.24 from 2020-08-04
@@ -61,4 +63,4 @@ typedef enum {
   P124_ACCHARGE_TOTAL,
 } eP124InputRegisters_t;
 
-void init_growatt124(sProtocolDefinition_t &Protocol);
+void init_growatt124(sProtocolDefinition_t &Protocol, Growatt &inverter);

--- a/SRC/ShineWiFi-ModBus/Growatt305.cpp
+++ b/SRC/ShineWiFi-ModBus/Growatt305.cpp
@@ -1,8 +1,9 @@
 #include "Arduino.h"
 
+#include "Growatt.h"
 #include "Growatt305.h"
 
-void init_growatt305(sProtocolDefinition_t &Protocol) {
+void init_growatt305(sProtocolDefinition_t& Protocol, Growatt& inverter) {
   // definition of input registers
   Protocol.InputRegisterCount = 12;
   // address, value, size, name, multiplier, unit, frontend, plot

--- a/SRC/ShineWiFi-ModBus/Growatt305.h
+++ b/SRC/ShineWiFi-ModBus/Growatt305.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "Arduino.h"
+#include "Growatt.h"
 #include "GrowattTypes.h"
 
 // Growatt modbus protocol version 1.24 from 2020-08-04
@@ -19,4 +20,4 @@ typedef enum {
   P305_TEMPERATURE,
 } eP305InputRegisters_t;
 
-void init_growatt305(sProtocolDefinition_t &Protocol);
+void init_growatt305(sProtocolDefinition_t& Protocol, Growatt& inverter);

--- a/SRC/ShineWiFi-ModBus/GrowattSPF.cpp
+++ b/SRC/ShineWiFi-ModBus/GrowattSPF.cpp
@@ -1,12 +1,13 @@
 #include "Arduino.h"
 
+#include "Growatt.h"
 #include "GrowattSPF.h"
 
 /* Tested on Growatt SPF5000ES
    Replacing ShineWifi-F "USB" stick
 */
 
-void init_growattSPF(sProtocolDefinition_t &Protocol) {
+void init_growattSPF(sProtocolDefinition_t& Protocol, Growatt& inverter) {
   // definition of input registers
   Protocol.InputRegisterCount = 27;
   // address, value, size, name, multiplier, unit, frontend, plot

--- a/SRC/ShineWiFi-ModBus/GrowattSPF.h
+++ b/SRC/ShineWiFi-ModBus/GrowattSPF.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "Arduino.h"
+#include "Growatt.h"
 #include "GrowattTypes.h"
 
 // Growatt modbus protocol version unknown from 2020-10-16
@@ -36,4 +37,4 @@ typedef enum {
   SPF_BATT_PWR
 } eSPFInputRegisters_t;
 
-void init_growattSPF(sProtocolDefinition_t &Protocol);
+void init_growattSPF(sProtocolDefinition_t& Protocol, Growatt& inverter);

--- a/SRC/ShineWiFi-ModBus/ShineMqtt.h
+++ b/SRC/ShineWiFi-ModBus/ShineMqtt.h
@@ -5,6 +5,7 @@
 #if MQTT_SUPPORTED == 1
 #include <Arduino.h>
 #include "ShineWifi.h"
+#include "Growatt.h"
 #include <PubSubClient.h>
 #include <stdbool.h>
 
@@ -18,10 +19,11 @@ typedef struct {
 
 class ShineMqtt {
  public:
-  ShineMqtt(WiFiClient& wc) : wifiClient(wc), mqttclient(wifiClient){};
+  ShineMqtt(WiFiClient& wc, Growatt& inverter);
   void mqttSetup(const MqttConfig& config);
   bool mqttReconnect();
   void mqttPublish(const String& JsonString);
+  void onMqttMessage(char* topic, byte* payload, unsigned int length);
   void updateMqttLed();
   void loop();
 
@@ -30,6 +32,7 @@ class ShineMqtt {
   long previousConnectTryMillis = 0;
   MqttConfig mqttconfig;
   PubSubClient mqttclient;
+  Growatt& inverter;
   static String getId();
 };
 #endif

--- a/SRC/ShineWiFi-ModBus/ShineWiFi-ModBus.ino
+++ b/SRC/ShineWiFi-ModBus/ShineWiFi-ModBus.ino
@@ -62,18 +62,18 @@ e.g. C:\Users\<username>\AppData\Local\Temp\arduino_build_533155
     #include "ShineMqtt.h"
 #endif
 
+Preferences prefs;
+Growatt Inverter;
+bool StartedConfigAfterBoot = false;
+
 #if MQTT_SUPPORTED == 1
     #ifdef MQTTS_ENABLED
         WiFiClientSecure espClient;
     #else
         WiFiClient espClient;
     #endif
-    ShineMqtt shineMqtt(espClient);
+    ShineMqtt shineMqtt(espClient, Inverter);
 #endif
-
-Preferences prefs;
-Growatt Inverter;
-bool StartedConfigAfterBoot = false;
 
 #ifdef AP_BUTTON_PRESSED
 byte btnPressed = 0;


### PR DESCRIPTION
I've created a new MQTT command API which depending on your modbus version will allow you to perform specific actions against the inverter, particularly ones that would not normally be possible through the RW modbus page as e.g. they require writing multiple registers at the same time on the inverter firmware or it rejects the update.

Currently, you can retrieve and set the datetime on v1.24 inverters with a MQTT API. I later plan to add the ability to manage the schedules for e.g. charging off the grid at night time (#167) but wanted to get some early feedback with the general approach I've gone for here before continuing with that.

Note I'm not primarily a C++ / microcontroller developer and mostly work in more managed languages like C# so I apologise if I've made any silly mistakes here. Looking forward to hearing your feedback!

I will squash the commits and add the commit sign-off once you're happy with everything but I figured there's probably going to at least be one change I need to make before it's good to go so didn't bother yet.

Example commands:

### Get datetime

![image](https://github.com/otti/Growatt_ShineWiFi-S/assets/2363642/6f7db746-8ef1-4c8a-95e2-8a64c598a3b2)

### Set datetime

![image](https://github.com/otti/Growatt_ShineWiFi-S/assets/2363642/c0faced1-fc26-4e07-92fc-2cc761705c65)

Tested on simulated inverter and growatt 600 tl-x.
