### PR TITLE
Add modbus RW interface to MQTT commands

### DIFF
--- a/SRC/ShineWiFi-ModBus/Growatt.h
+++ b/SRC/ShineWiFi-ModBus/Growatt.h
@@ -48,4 +48,10 @@ class Growatt {
   std::tuple<bool, String> handleCommandList(const DynamicJsonDocument& req,
                                              DynamicJsonDocument& res,
                                              Growatt& inverter);
+  std::tuple<bool, String> handleModbusGet(const DynamicJsonDocument& req,
+                                           DynamicJsonDocument& res,
+                                           Growatt& inverter);
+  std::tuple<bool, String> handleModbusSet(const DynamicJsonDocument& req,
+                                           DynamicJsonDocument& res,
+                                           Growatt& inverter);
 };


### PR DESCRIPTION
As promised in my last PR #201 here is a MQTT version of the postCommunicationModbus HTTP API. I did not remove the original as I was not sure if you wanted to keep it for now or not, happy to add that to this PR as well if you want.

Examples:
-------
![image](https://github.com/otti/Growatt_ShineWiFi-S/assets/2363642/6ff4be01-86c9-4d54-a25f-f23513fd2bad)
-------
![image](https://github.com/otti/Growatt_ShineWiFi-S/assets/2363642/877106c5-7cad-419f-bb27-7f2f1831f995)

