### PR TITLE
Add battery / grid first commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,10 @@ To receive responses to commands you can use templates.
     payload: "ha-datetime-get"
   sensor:
     name: Growatt - Inverter date/time
-    state: "{{ trigger.payload_json.message }}"
+    state: "{{ trigger.payload_json.value }}"
+    attributes:
+      success: "{{ trigger.payload_json.success }}"
+      message: "{{ trigger.payload_json.message }}"
 ```
 
 ```yaml


### PR DESCRIPTION
This PR adds new commands for the v1.24 modbus version that allows the user to read and update the various battery and grid first settings, which allows them to e.g. charge their battery from the grid overnight. It is a 1:1 match of the 'Battery First' and 'Grid First' settings on the official Growatt server config page.

I was unable to get the 'Battery First1' and 'Grid First1' equivalents functional as the inverter responded very strangely to setting the values as documented so I have left them out, it is unlikely to have more than 3 schedules anyway.

I have also updated the `datetime/get` command to return the datetime in the `value` field instead of `message` to make it nicer, and updated the Home Assistant example in the README to match.

Fixes #167

Examples:
---------
### Getting battery first data
Request:
```jsonc
// energy/solar/command/batteryfirst/get
{}
```
Response:
```jsonc
{
  "powerRate": 100,
  "stopSOC": 100,
  "acChargeEnabled": true,
  "timeSlots": [
    {
      "slot": 1,
      "start": "00:30",
      "stop": "04:30",
      "enabled": true
    },
    {
      "slot": 2,
      "start": "00:00",
      "stop": "00:00",
      "enabled": false
    },
    {
      "slot": 3,
      "start": "00:00",
      "stop": "00:00",
      "enabled": false
    }
  ],
  "command": "batteryfirst/get",
  "success": true,
  "message": "success"
}
```

### Setting battery first time slot
Request:
```jsonc
// energy/solar/command/batteryfirst/set/timeslot
{
  "start": "04:30",
  "stop": "06:45",
  "enabled": true,
  "slot": 2
}
```
Response:
```jsonc
{
  "command": "batteryfirst/set/timeslot",
  "success": true,
  "message": "success"
}
```