### PR TITLE
Output a link to the AP configuration page

### DIFF
--- a/SRC/ShineWiFi-ModBus/ShineWiFi-ModBus.ino
+++ b/SRC/ShineWiFi-ModBus/ShineWiFi-ModBus.ino
@@ -370,12 +370,12 @@ void sendMqttJson(void)
     shineMqtt.mqttPublish(doc);
 }
 #endif
-    
+
 void StartConfigAccessPoint(void)
 {
     String Text;
-    Text = "Configuration access point started ...\r\nConnect to Wifi: \"GrowattConfig\" with your password (default: \"growsolar\") and visit 192.168.4.1\r\nThe Stick will automatically go back to normal operation after " + String(CONFIG_PORTAL_MAX_TIME_SECONDS) + " seconds";
-    httpServer.send(200, "text/plain", Text);
+    Text = "<html><body>Configuration access point started ...<br /><br />Connect to Wifi: \"GrowattConfig\" with your password (default: \"growsolar\") and visit <a href='http://192.168.4.1'>192.168.4.1</a><br />The Stick will automatically go back to normal operation after " + String(CONFIG_PORTAL_MAX_TIME_SECONDS) + " seconds</body></html>";
+    httpServer.send(200, "text/html", Text);
     StartedConfigAfterBoot = true;
 }
 


### PR DESCRIPTION
With this change, the page looks a tiny little bit nicer and has a link to click on instead of having to copy & paste or manually write the IP.

<img width="664" alt="bild" src="https://github.com/otti/Growatt_ShineWiFi-S/assets/1417619/ca59fb55-699b-4f78-b55e-8e288bc85ec7">